### PR TITLE
Replace os-locale with native electron api, app.getLocale

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,6 @@
     "electron-updater": "2.20.1",
     "keytar": "4.1.0",
     "node-forge": "0.7.1",
-    "os-locale": "2.1.0",
     "rxjs": "5.5.6",
     "zone.js": "0.8.19"
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,9 +12,6 @@ import { PowerMonitorMain } from './main/powerMonitor.main';
 import { UpdaterMain } from './main/updater.main';
 import { WindowMain } from './main/window.main';
 
-// tslint:disable-next-line
-const osLocale = require('os-locale');
-
 export class Main {
     logService: LogService;
     i18nService: I18nService;
@@ -65,8 +62,8 @@ export class Main {
 
     bootstrap() {
         this.windowMain.init().then(async () => {
-            const locale = await osLocale();
-            await this.i18nService.init(locale.replace('_', '-'));
+            const locale = app.getLocale();
+            await this.i18nService.init(locale);
             this.messagingMain.init();
             this.menuMain.init();
             this.powerMonitorMain.init();

--- a/src/package.json
+++ b/src/package.json
@@ -16,7 +16,6 @@
     "electron-log": "2.2.14",
     "electron-store": "1.3.0",
     "electron-updater": "2.20.1",
-    "keytar": "4.1.0",
-    "os-locale": "2.1.0"
+    "keytar": "4.1.0"
   }
 }


### PR DESCRIPTION
The native electron API seems to grab a more *correct* locale than the `os-locale` package on my machine.