### PR TITLE
Tray icon

### DIFF
--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -43,6 +43,16 @@
                             <small class="help-block">{{'disableFaviconDesc' | i18n}}</small>
                         </div>
                         <div class="form-group">
+                            <div class="checkbox">
+                                <label for="enableHideInTray">
+                                    <input id="enableHideInTray" type="checkbox" name="EnableHideInTray"
+                                           [(ngModel)]="enableHideInTray" (change)="saveHideInTray()">
+                                    {{'enableHideInTray' | i18n}}
+                                </label>
+                            </div>
+                            <small class="help-block">{{'enableHideInTrayDesc' | i18n}}</small>
+                        </div>
+                        <div class="form-group">
                             <label for="locale">{{'language' | i18n}}</label>
                             <select id="locale" name="Locale" [(ngModel)]="locale" (change)="saveLocale()">
                                 <option *ngFor="let o of localeOptions" [ngValue]="o.value">{{o.name}}</option>

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -83,12 +83,12 @@ export class SettingsComponent implements OnInit {
         await this.storageService.save(ConstantsService.disableFaviconKey, this.disableFavicons);
         await this.stateService.save(ConstantsService.disableFaviconKey, this.disableFavicons);
         this.messagingService.send('refreshCiphers');
-        this.callAnalytics('Favicons', !this.disableGa);
+        this.callAnalytics('Favicons', !this.disableFavicons);
     }
 
     async saveHideInTray() {
         await this.storageService.save(DesktopConstantsService.enableHideInTrayKey, this.enableHideInTray);
-        this.callAnalytics('HideInTray', !this.disableGa);
+        this.callAnalytics('HideInTray', this.enableHideInTray);
     }
 
     async saveLocale() {

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -14,6 +14,7 @@ import { StateService } from 'jslib/abstractions/state.service';
 import { StorageService } from 'jslib/abstractions/storage.service';
 
 import { ConstantsService } from 'jslib/services/constants.service';
+import { DesktopConstantsService } from '../../services/desktopconstants.service';
 
 @Component({
     selector: 'app-settings',
@@ -23,6 +24,7 @@ export class SettingsComponent implements OnInit {
     lockOption: number = null;
     disableGa: boolean = false;
     disableFavicons: boolean = false;
+    enableHideInTray: boolean = false;
     locale: string;
     lockOptions: any[];
     localeOptions: any[];
@@ -55,6 +57,7 @@ export class SettingsComponent implements OnInit {
     async ngOnInit() {
         this.lockOption = await this.storageService.get<number>(ConstantsService.lockOptionKey);
         this.disableFavicons = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
+        this.enableHideInTray = await this.storageService.get<boolean>(DesktopConstantsService.enableHideInTrayKey);
         this.locale = await this.storageService.get<string>(ConstantsService.localeKey);
 
         const disableGa = await this.storageService.get<boolean>(ConstantsService.disableGaKey);
@@ -81,6 +84,11 @@ export class SettingsComponent implements OnInit {
         await this.stateService.save(ConstantsService.disableFaviconKey, this.disableFavicons);
         this.messagingService.send('refreshCiphers');
         this.callAnalytics('Favicons', !this.disableGa);
+    }
+
+    async saveHideInTray() {
+        await this.storageService.save(DesktopConstantsService.enableHideInTrayKey, this.enableHideInTray);
+        this.callAnalytics('HideInTray', !this.disableGa);
     }
 
     async saveLocale() {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -770,6 +770,12 @@
   "disableFaviconDesc": {
     "message": "Website Icons provide a recognizable image next to each login item in your vault."
   },
+  "enableHideInTray": {
+    "message": "Hide Bitwarden in tray"
+  },
+  "enableHideInTrayDesc": {
+    "message": "Bitwarden will stay in your system tray when minimizing the window."
+  },
   "language": {
     "message": "Language"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { I18nService } from './services/i18n.service';
 import { MenuMain } from './main/menu.main';
 import { MessagingMain } from './main/messaging.main';
 import { PowerMonitorMain } from './main/powerMonitor.main';
+import { TrayMain } from './main/tray.main';
 import { UpdaterMain } from './main/updater.main';
 
 import { ConstantsService } from 'jslib/services/constants.service';
@@ -28,6 +29,7 @@ export class Main {
     updaterMain: UpdaterMain;
     menuMain: MenuMain;
     powerMonitorMain: PowerMonitorMain;
+    trayMain: TrayMain;
 
     constructor() {
         // Set paths for portable builds
@@ -66,6 +68,7 @@ export class Main {
         this.updaterMain = new UpdaterMain(this);
         this.menuMain = new MenuMain(this);
         this.powerMonitorMain = new PowerMonitorMain(this);
+        this.trayMain = new TrayMain(this);
 
         this.messagingService = new ElectronMainMessagingService(this.windowMain, (message) => {
             this.messagingMain.onMessage(message);
@@ -82,6 +85,7 @@ export class Main {
             this.messagingMain.init();
             this.menuMain.init();
             this.powerMonitorMain.init();
+            this.trayMain.init();
             await this.updaterMain.init();
         }, (e: any) => {
             // tslint:disable-next-line

--- a/src/main/tray.main.ts
+++ b/src/main/tray.main.ts
@@ -1,0 +1,48 @@
+import { Tray } from 'electron';
+import * as Path from 'path';
+import { Main } from '../main';
+import { DesktopConstantsService } from '../services/desktopconstants.service';
+
+export class TrayMain {
+    private tray: Tray;
+    private iconPath: string;
+
+    constructor(private main: Main) {
+        if (process.platform === 'win32') {
+            this.iconPath = Path.join(__dirname, '../resources/icon.ico');
+        } else {
+            this.iconPath = Path.join(__dirname, '../resources/icon.png');
+        }
+    }
+
+    init() {
+        this.main.windowMain.win.on('minimize', async (event: Event) => {
+            if (await this.main.storageService.get<boolean>(DesktopConstantsService.enableHideInTrayKey)) {
+                event.preventDefault();
+                await this.handleHideEvent();
+            }
+        });
+        this.main.windowMain.win.on('show', async (event: Event) => {
+            await this.handleShowEvent();
+        });
+    }
+
+    private handleShowEvent() {
+        if (this.tray) {
+            this.tray.destroy();
+            this.tray = null;
+        }
+    }
+
+    private handleHideEvent() {
+        this.tray = new Tray(this.iconPath);
+        this.tray.on('click', () => {
+            if (this.main.windowMain.win.isVisible()) {
+                this.main.windowMain.win.hide();
+            } else {
+                this.main.windowMain.win.show();
+            }
+        });
+        this.main.windowMain.win.hide();
+    }
+}

--- a/src/services/desktopconstants.service.ts
+++ b/src/services/desktopconstants.service.ts
@@ -1,0 +1,5 @@
+export class DesktopConstantsService {
+    static readonly enableHideInTrayKey: string = 'enableHideInTray';
+
+    readonly enableHideInTrayKey: string = DesktopConstantsService.enableHideInTrayKey;
+}


### PR DESCRIPTION
This pull request implements a hide-to-tray functionality. This feature is configurable in the settings and defaults to being not activated.

The tray icon is only shown if the window is minimized, which also hides the window from the taskbar.
Some users may want to keep the tray icon visible all the time or to prevent closing the window in favour of showing the icon. Both improvements can be done very quickly.

I also included the localization strings for English (please be aware that I'm not a native speaker).