### PR TITLE
Replace carat icon with folder icon for groupings

### DIFF
--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -46,7 +46,7 @@
             <ul class="fa-ul">
                 <li *ngFor="let f of folders" [ngClass]="{active: selectedFolder && f.id === selectedFolderId}">
                     <a href="#" appStopClick appBlurClick (click)="selectFolder(f)">
-                        <i class="fa-li fa fa-caret-right"></i> {{f.name}}
+                        <i class="fa-li fa fa-folder"></i> {{f.name}}
                         <span appStopProp appStopClick (click)="editFolder(f)" title="{{'editFolder' | i18n}}"
                               *ngIf="f.id">
                             <i class="fa fa-pencil fa-fw"></i>
@@ -59,7 +59,7 @@
                 <ul class="fa-ul">
                     <li *ngFor="let c of collections" [ngClass]="{active: c.id === selectedCollectionId}">
                         <a href="#" appStopClick appBlurClick (click)="selectCollection(c)">
-                            <i class="fa-li fa fa-caret-right"></i> {{c.name}}
+                            <i class="fa-li fa fa-folder"></i> {{c.name}}
                         </a>
                     </li>
                 </ul>

--- a/src/scss/vault.scss
+++ b/src/scss/vault.scss
@@ -71,16 +71,16 @@
                 word-break: break-all;
 
                 .fa-li {
-                    left: -11px;
+                    left: -7px;
                     top: 8px;
                 }
 
                 a {
-                    padding-left: 12px;
+                    padding-left: 22px;
                 }
 
                 &.active .fa-li {
-                    left: 4px;
+                    left: 8px;
                 }
             }
         }


### PR DESCRIPTION
To address this [community discussion](https://community.bitwarden.com/t/folders-have-chevron-when-they-arent-expandable/1524/2).

![screen shot 2018-09-17 at 3 52 45 pm](https://user-images.githubusercontent.com/31694/45652550-2e534200-ba92-11e8-9e1d-6048aaf2f1c7.png)
