### PR TITLE
Add keybinding to open settings

### DIFF
--- a/src/main/menu.main.ts
+++ b/src/main/menu.main.ts
@@ -370,6 +370,7 @@ export class MenuMain extends BaseMenu {
                 label: this.main.i18nService.t('settings'),
                 id: 'settings',
                 click: () => this.main.messagingService.send('openSettings'),
+                accelerator: 'CmdOrCtrl+,',
             },
             {
                 label: this.main.i18nService.t('lockNow'),


### PR DESCRIPTION
This PR adds a keyboard shortcut to open settings.

In OS X: `Cmd + ,`
In Windows/Linux: `Ctrl + ,` (not tested)