### PR TITLE
More prominent password exposed warning

### DIFF
--- a/src/app/vault/view.component.html
+++ b/src/app/vault/view.component.html
@@ -1,5 +1,12 @@
 <div class="content">
     <div class="inner-content" *ngIf="cipher">
+        <div class="box warning" *ngIf="exposed">
+            <div class="box-content">
+                    <div class="box-content-row">
+                        {{'passwordExposed' | i18n: exposed}}
+                    </div>
+            </div>
+        </div>
         <div class="box">
             <div class="box-header">
                 {{'itemInformation' | i18n}}

--- a/src/scss/vault.scss
+++ b/src/scss/vault.scss
@@ -316,6 +316,14 @@
             @include themify($themes) {
                 background: themed('warningColor');
             }
+
+            .box-content-row {
+                &:hover, &:focus, &.active {
+                    @include themify($themes) {
+                        background: themed('warningColor');
+                    }
+                }
+            }
         }
     }
 

--- a/src/scss/vault.scss
+++ b/src/scss/vault.scss
@@ -309,6 +309,14 @@
             flex-direction: column;
             height: 100%;
         }
+
+        .box.warning .box-content{
+            color: #fff;
+
+            @include themify($themes) {
+                background: themed('warningColor');
+            }
+        }
     }
 
     > #logo {


### PR DESCRIPTION
This PR displays a more prominent warning message when an exposed password has been detected.

Depends on https://github.com/bitwarden/jslib/pull/15

![electron_2018-10-26_20-45-39](https://user-images.githubusercontent.com/137855/47586430-8407ed80-d960-11e8-90a8-1874a3fe6b66.png)

