### PR TITLE
Close to tray

### DIFF
--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -52,6 +52,16 @@
                             </div>
                             <small class="help-block">{{'enableMinToTrayDesc' | i18n}}</small>
                         </div>
+                        <div class="form-group" *ngIf="showMinToTray">
+                            <div class="checkbox">
+                                <label for="enableCloseToTray">
+                                    <input id="enableCloseToTray" type="checkbox" name="EnableCloseToTray"
+                                           [(ngModel)]="enableCloseToTray" (change)="saveCloseToTray()">
+                                    {{'enableCloseToTray' | i18n}}
+                                </label>
+                            </div>
+                            <small class="help-block">{{'enableCloseToTrayDesc' | i18n}}</small>
+                        </div>
                         <div class="form-group">
                             <div class="checkbox">
                                 <label for="disableGa">

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -30,6 +30,7 @@ export class SettingsComponent implements OnInit {
     disableGa: boolean = false;
     disableFavicons: boolean = false;
     enableMinToTray: boolean = false;
+    enableCloseToTray: boolean = false;
     enableTray: boolean = false;
     showMinToTray: boolean = false;
     locale: string;
@@ -78,6 +79,7 @@ export class SettingsComponent implements OnInit {
         this.lockOption = await this.storageService.get<number>(ConstantsService.lockOptionKey);
         this.disableFavicons = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
         this.enableMinToTray = await this.storageService.get<boolean>(ElectronConstants.enableMinimizeToTrayKey);
+        this.enableCloseToTray = await this.storageService.get<boolean>(ElectronConstants.enableCloseToTrayKey);
         this.enableTray = await this.storageService.get<boolean>(ElectronConstants.enableTrayKey);
         this.locale = await this.storageService.get<string>(ConstantsService.localeKey);
         this.theme = await this.storageService.get<string>(ConstantsService.themeKey);
@@ -111,6 +113,11 @@ export class SettingsComponent implements OnInit {
     async saveMinToTray() {
         await this.storageService.save(ElectronConstants.enableMinimizeToTrayKey, this.enableMinToTray);
         this.callAnalytics('MinimizeToTray', this.enableMinToTray);
+    }
+
+    async saveCloseToTray() {
+        await this.storageService.save(ElectronConstants.enableCloseToTrayKey, this.enableCloseToTray);
+        this.callAnalytics('CloseToTray', this.enableCloseToTray);
     }
 
     async saveTray() {

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -75,7 +75,7 @@ export class SettingsComponent implements OnInit {
     }
 
     async ngOnInit() {
-        this.showMinToTray = this.platformUtilsService.getDevice() === DeviceType.WindowsDesktop || this.platformUtilsService.getDevice() === DeviceType.LinuxDesktop;
+        this.showMinToTray = this.platformUtilsService.getDevice() === DeviceType.WindowsDesktop;
         this.lockOption = await this.storageService.get<number>(ConstantsService.lockOptionKey);
         this.disableFavicons = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
         this.enableMinToTray = await this.storageService.get<boolean>(ElectronConstants.enableMinimizeToTrayKey);

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -75,7 +75,7 @@ export class SettingsComponent implements OnInit {
     }
 
     async ngOnInit() {
-        this.showMinToTray = this.platformUtilsService.getDevice() === DeviceType.WindowsDesktop;
+        this.showMinToTray = this.platformUtilsService.getDevice() === DeviceType.WindowsDesktop || this.platformUtilsService.getDevice() === DeviceType.LinuxDesktop;
         this.lockOption = await this.storageService.get<number>(ConstantsService.lockOptionKey);
         this.disableFavicons = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
         this.enableMinToTray = await this.storageService.get<boolean>(ElectronConstants.enableMinimizeToTrayKey);

--- a/src/locales/de/messages.json
+++ b/src/locales/de/messages.json
@@ -806,6 +806,12 @@
   "enableMinToTrayDesc": {
     "message": "Zeige ein Symbol in der Taskleiste, wenn das Fenster minimiert wird."
   },
+  "enableCloseToTray": {
+    "message": "Beim Schließen minimieren"
+  },
+  "enableCloseToTrayDesc": {
+    "message": "Bitwarden zu einem Symbol in der Taskleiste minimieren sobald das Fenster geschlossen wird."
+  },
   "enableTray": {
     "message": "Taskleisten-Symbol einschalten"
   },

--- a/src/locales/de/messages.json
+++ b/src/locales/de/messages.json
@@ -806,12 +806,6 @@
   "enableMinToTrayDesc": {
     "message": "Zeige ein Symbol in der Taskleiste, wenn das Fenster minimiert wird."
   },
-  "enableCloseToTray": {
-    "message": "Beim Schließen minimieren"
-  },
-  "enableCloseToTrayDesc": {
-    "message": "Bitwarden zu einem Symbol in der Taskleiste minimieren sobald das Fenster geschlossen wird."
-  },
   "enableTray": {
     "message": "Taskleisten-Symbol einschalten"
   },

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -806,6 +806,12 @@
   "enableMinToTrayDesc": {
     "message": "When minimizing the window, show an icon in the system tray instead."
   },
+  "enableCloseToTray": {
+    "message": "Close to Tray Icon"
+  },
+  "enableCloseToTrayDesc": {
+    "message": "When closing the window, show an icon in the system tray instead."
+  },
   "enableTray": {
     "message": "Enable Tray Icon"
   },

--- a/src/main/menu.main.ts
+++ b/src/main/menu.main.ts
@@ -365,6 +365,9 @@ export class MenuMain extends BaseMenu {
                 click: () => this.main.messagingService.send('lockVault'),
                 accelerator: 'CmdOrCtrl+L',
             },
+        ];
+
+        const firstMenuOptionsWindowsLinux: MenuItemConstructorOptions[] = [
             {
                 label: this.i18nService.t('quitBitwarden'),
                 role: 'quit',
@@ -402,6 +405,10 @@ export class MenuMain extends BaseMenu {
             // File menu
             template[0].submenu = (template[0].submenu as MenuItemConstructorOptions[]).concat(
                 firstMenuOptions);
+            if(process.platform === 'linux' || process.platform === 'win32') {
+                template[0].submenu = (template[0].submenu as MenuItemConstructorOptions[]).concat(
+                    firstMenuOptionsWindowsLinux);
+            }
 
             // About menu
             const aboutMenuAdditions: MenuItemConstructorOptions[] = [

--- a/src/main/menu.main.ts
+++ b/src/main/menu.main.ts
@@ -365,6 +365,10 @@ export class MenuMain extends BaseMenu {
                 click: () => this.main.messagingService.send('lockVault'),
                 accelerator: 'CmdOrCtrl+L',
             },
+            {
+                label: this.i18nService.t('quitBitwarden'),
+                role: 'quit',
+            },
         ];
 
         const updateMenuItem = {


### PR DESCRIPTION
Allow the app to be minimized to the tray icon if the window gets closed. This is disabled by default.

Tested (and therefore enabled for linux) on Archlinux.

Needed jslib changes: https://github.com/bitwarden/jslib/pull/21