### PR TITLE
Fix failing build for node 11, see gulpjs/gulp#2246

### DIFF
--- a/package.json
+++ b/package.json
@@ -253,6 +253,7 @@
     "keytar": "4.2.1",
     "lowdb": "1.0.0",
     "lunr": "2.3.3",
+    "natives": "^1.1.6",
     "node-forge": "0.7.6",
     "nord": "0.2.1",
     "papaparse": "4.6.0",


### PR DESCRIPTION
This fixes the failing build on Archlinux using Node 11.

See https://github.com/gulpjs/gulp/issues/2246 for details.