### PR TITLE
fix: Remove unnecessary async

### DIFF
--- a/src/main/powerMonitor.main.ts
+++ b/src/main/powerMonitor.main.ts
@@ -49,7 +49,7 @@ export class PowerMonitorMain {
         // TODO: System locked
     }
 
-    private async getLockOption(): Promise<number> {
-        return await this.main.storageService.get<number>(ConstantsService.lockOptionKey);
+    private getLockOption(): Promise<number> {
+        return this.main.storageService.get<number>(ConstantsService.lockOptionKey);
     }
 }


### PR DESCRIPTION
This PR will
* not change any behavior
* return the promise in `getLockOption()` directly instead of awaiting it.