### PR TITLE
Prettier UI on macOS

### DIFF
--- a/src/scss/environment.scss
+++ b/src/scss/environment.scss
@@ -7,3 +7,33 @@
         border-top-color: #000000;
     }
 }
+
+html.os_macos {
+    body {
+        -webkit-app-region: drag
+    }
+
+    button, a, span, input, p, h1, h2, h3, h4, h5, h6, img, select, textarea, .box {
+        -webkit-app-region: no-drag;
+    }
+
+    #login-page, #register-page, #hint-page, #two-factor-page, #lock-page {
+        .content {
+            a.settings-icon {
+                position: absolute;
+                left: unset;
+                right: 10px;
+
+                span {
+                    margin-right: 8px;
+                    float: left;
+                }
+            }
+        }
+    }
+
+    #groupings {
+        padding-top: 24px;
+    }
+
+}


### PR DESCRIPTION
Main goal of this change is to remove ugly (at least in my opinion) title bar from application on macOS, which looks terrible when app is using dark and nord themes. This is a simple css change in desktop, with additional change in jslib (also a PR) to allow electron to hide titlebar on 'darwin' platforms.

Application is draggable by most of the empty spaces.

I tested it as well as I could, to make sure important elements do not cause window to be dragged. If there are any left, let me know. I hope i didn't break anything (I shouldn't really, this is just CSS).

Here are screenshots after changes:

![bitwarden-macos-2](https://user-images.githubusercontent.com/802214/56075556-b6998b80-5dc4-11e9-97fb-bbc982877174.png)
![bitwarden-macos-1](https://user-images.githubusercontent.com/802214/56075557-b6998b80-5dc4-11e9-8319-c7d95d9a63c1.png)
![bitwarden-macos-3](https://user-images.githubusercontent.com/802214/56075558-b6998b80-5dc4-11e9-904c-20a936f4f703.png)
![bitwarden-macos-4](https://user-images.githubusercontent.com/802214/56075559-b6998b80-5dc4-11e9-8a4e-33949b0f622d.png)
