### PR TITLE
Disable favicons by default

### DIFF
--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -31,7 +31,7 @@ import { Utils } from 'jslib/misc/utils';
 export class SettingsComponent implements OnInit {
     lockOption: number = null;
     pin: boolean = null;
-    disableFavicons: boolean = false;
+    disableFavicons: boolean = true;
     enableMinToTray: boolean = false;
     enableCloseToTray: boolean = false;
     enableTray: boolean = false;


### PR DESCRIPTION
## Summary
* Disable website icons (by default) by setting disableFavicons to true in SettingsComponent.
* Stopgap solution until Electron is updated.
* See also issue #244.

## Context
Upon encountering a malformed favicon the renderer process crashes, leaving the application in an unusable state. Once the crash has occurred, the user cannot even disable website icons through settings. Since this issue results in the application being unavailable to the user, an urgent fix is required.
