### PR TITLE
add window option: always on top of other windows

### DIFF
--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1143,6 +1143,10 @@
   "hideToTray": {
     "message": "Hide to Tray"
   },
+  "alwaysOnTop": {
+    "message": "Always on Top",
+    "description": "Bitwarden window should always stay on top of other windows"
+  },
   "dateUpdated": {
     "message": "Updated",
     "description": "ex. Date this item was updated"

--- a/src/main/menu.main.ts
+++ b/src/main/menu.main.ts
@@ -450,8 +450,8 @@ export class MenuMain extends BaseMenu {
             {
                 type: 'checkbox',
                 label: this.main.i18nService.t('alwaysOnTop'),
-                checked: this.windowMain.win.isAlwaysOnTop() ? true : false,
-                click: () => this.main.messagingService.send('alwaysOnTop'),
+                checked: this.windowMain.win.isAlwaysOnTop(),
+                click: () => this.main.windowMain.toggleAlwaysOnTop(),
                 accelerator: 'CmdOrCtrl+Shift+T',
             },
         );

--- a/src/main/menu.main.ts
+++ b/src/main/menu.main.ts
@@ -441,11 +441,20 @@ export class MenuMain extends BaseMenu {
                 (template[template.length - 1].submenu as MenuItemConstructorOptions[]).concat(aboutMenuAdditions);
         }
 
-        (template[template.length - 2].submenu as MenuItemConstructorOptions[]).splice(1, 0, {
-            label: this.main.i18nService.t('hideToTray'),
-            click: () => this.main.messagingService.send('hideToTray'),
-            accelerator: 'CmdOrCtrl+Shift+M',
-        });
+        (template[template.length - 2].submenu as MenuItemConstructorOptions[]).splice(1, 0,
+            {
+                label: this.main.i18nService.t('hideToTray'),
+                click: () => this.main.messagingService.send('hideToTray'),
+                accelerator: 'CmdOrCtrl+Shift+M',
+            },
+            {
+                type: 'checkbox',
+                label: this.main.i18nService.t('alwaysOnTop'),
+                checked: this.windowMain.win.isAlwaysOnTop() ? true : false,
+                click: () => this.main.messagingService.send('alwaysOnTop'),
+                accelerator: 'CmdOrCtrl+Shift+T',
+            },
+        );
 
         this.menu = Menu.buildFromTemplate(template);
         Menu.setApplicationMenu(this.menu);

--- a/src/main/messaging.main.ts
+++ b/src/main/messaging.main.ts
@@ -32,9 +32,6 @@ export class MessagingMain {
             case 'hideToTray':
                 this.main.trayMain.hideToTray();
                 break;
-            case 'alwaysOnTop':
-                this.main.windowMain.alwaysOnTop();
-                break;
             default:
                 break;
         }

--- a/src/main/messaging.main.ts
+++ b/src/main/messaging.main.ts
@@ -32,6 +32,9 @@ export class MessagingMain {
             case 'hideToTray':
                 this.main.trayMain.hideToTray();
                 break;
+            case 'alwaysOnTop':
+                this.main.windowMain.alwaysOnTop();
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
Adds a checkbox option to the window menu which makes Bitwarden always stay on top of other windows. This is really useful when copying more than one thing to an other program because the window doesn't get minimized. This option is disabled by default.

Needed jslib changes: [https://github.com/bitwarden/jslib/pull/41](https://github.com/bitwarden/jslib/pull/41)

![image](https://user-images.githubusercontent.com/6097749/58707123-48c91380-83b4-11e9-84d3-31a701f57bf9.png)
