### PR TITLE
If an environment is configured, show the hostname in the lock screen

### DIFF
--- a/src/app/accounts/lock.component.html
+++ b/src/app/accounts/lock.component.html
@@ -24,7 +24,10 @@
                     </div>
                 </div>
             </div>
-            <div class="box-footer">
+            <div class="box-footer" *ngIf="webVaultHostname">
+                {{'loggedInAsOn' | i18n : email:webVaultHostname}}
+            </div>
+            <div class="box-footer" *ngIf="!webVaultHostname">
                 {{'loggedInAs' | i18n : email}}
             </div>
         </div>

--- a/src/app/accounts/lock.component.ts
+++ b/src/app/accounts/lock.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 
+import { EnvironmentService } from 'jslib/abstractions/environment.service';
 import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { LockService } from 'jslib/abstractions/lock.service';
@@ -19,8 +20,8 @@ export class LockComponent extends BaseLockComponent {
     constructor(router: Router, i18nService: I18nService,
         platformUtilsService: PlatformUtilsService, messagingService: MessagingService,
         userService: UserService, cryptoService: CryptoService,
-        storageService: StorageService, lockService: LockService) {
+        storageService: StorageService, lockService: LockService, environmentService: EnvironmentService) {
         super(router, i18nService, platformUtilsService, messagingService, userService, cryptoService,
-            storageService, lockService);
+            storageService, lockService, environmentService);
     }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -749,6 +749,19 @@
       }
     }
   },
+  "loggedInAsOn": {
+    "message": "Logged in as $EMAIL$ on $WEBVAULTHOSTNAME$.",
+    "placeholders": {
+      "email": {
+        "content": "$1",
+        "example": "name@example.com"
+      },
+      "webVaultHostname": {
+        "content": "$2",
+        "example": "bitwarden.example.com"
+      }
+    }
+  },
   "invalidMasterPassword": {
     "message": "Invalid master password"
   },

--- a/src/locales/en_GB/messages.json
+++ b/src/locales/en_GB/messages.json
@@ -743,6 +743,19 @@
       }
     }
   },
+  "loggedInAsOn": {
+    "message": "Logged in as $EMAIL$ on $WEBVAULTHOSTNAME$.",
+    "placeholders": {
+      "email": {
+        "content": "$1",
+        "example": "name@example.com"
+      },
+      "webVaultHostname": {
+        "content": "$2",
+        "example": "bitwarden.example.com"
+      }
+    }
+  },
   "invalidMasterPassword": {
     "message": "Invalid master password"
   },

--- a/src/locales/en_GB/messages.json
+++ b/src/locales/en_GB/messages.json
@@ -743,19 +743,6 @@
       }
     }
   },
-  "loggedInAsOn": {
-    "message": "Logged in as $EMAIL$ on $WEBVAULTHOSTNAME$.",
-    "placeholders": {
-      "email": {
-        "content": "$1",
-        "example": "name@example.com"
-      },
-      "webVaultHostname": {
-        "content": "$2",
-        "example": "bitwarden.example.com"
-      }
-    }
-  },
   "invalidMasterPassword": {
     "message": "Invalid master password"
   },


### PR DESCRIPTION
This PR needs this other to be merged first: https://github.com/bitwarden/jslib/pull/42

This tries to implement this feature request: https://community.bitwarden.com/t/show-the-server-to-which-you-are-logged-in/5472
By showing the hostname of the custom environment, if one is configured, in the lock screen.