### PR TITLE
Add autotype

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "dist:win:ci": "npm run build && npm run pack:win:ci",
     "publish:lin": "npm run build && npm run clean:dist && build --linux --x64 -p always",
     "publish:mac": "npm run build && npm run clean:dist && build --mac -p always",
-    "publish:win": "npm run build && npm run clean:dist && build --win --x64 --ia32 -p always -c.win.certificateSubjectName=\"8bit Solutions LLC\""
+    "publish:win": "npm run build && npm run clean:dist && build --win --x64 --ia32 -p always -c.win.certificateSubjectName=\"8bit Solutions LLC\"",
+    "rebuild": "npm rebuild --runtime=electron --target=1.1.3 --disturl=https://atom.io/download/atom-shell --abi=48"
   },
   "build": {
     "appId": "com.bitwarden.desktop",
@@ -262,5 +263,8 @@
     "sweetalert": "2.1.2",
     "zone.js": "0.8.28",
     "zxcvbn": "4.4.2"
+  },
+  "optionalDependencies": {
+    "windows-build-tools": ""
   }
 }

--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -104,6 +104,33 @@
                         </div>
                     </div>
                 </div>
+                <div class="box">
+                    <div class="box-header">
+                        {{'autoType' | i18n}}
+                    </div>
+                    <div class="box-content box-content-padded">
+                        <div class="form-group">
+                            <div class="checkbox">
+                                <label for="enableAutoType">
+                                    <input id="enableAutoType" type="checkbox" name="enableAutoType" [(ngModel)]="enableAutoType" (change)="saveAutoType()">
+                                    {{'enableAutoType' | i18n}}
+                                </label>
+                            </div>
+                        </div>
+                        <div class="form-group">
+                            <label for="AutoTypeHotkey">{{'globalKeyboardShortcut' | i18n}}</label>
+                            <input id="AutoTypeHotkey" name="AutoTypeHotkey" [(ngModel)]="autoTypeHotkey"
+                                    (keypress)="saveAutoTypeHotkey($event)" type="text"/>
+                            <small class="help-block">{{'globalKeyboardShortcutHelp' | i18n}}</small>
+                        </div>
+                        <div class="form-group">
+                            <label for="AutoTypeDefaultSequence">{{'autoTypeDefaultSequence' | i18n}}</label>
+                            <input id="AutoTypeDefaultSequence" name="AutoTypeDefaultSequence" [(ngModel)]="autoTypeDefaultSequence"
+                                   (change)="saveAutoTypeDefaultSequence()" type="text"/>
+                            <small class="help-block">{{'autoTypeSequenceHelp' | i18n}}</small>
+                        </div>
+                    </div>
+                </div>
             </div>
             <div class="modal-footer">
                 <button type="button" data-dismiss="modal">{{'close' | i18n}}</button>

--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -1,82 +1,77 @@
-import { remote } from 'electron';
+import {remote} from 'electron';
 
-import {
-    APP_INITIALIZER,
-    LOCALE_ID,
-    NgModule,
-} from '@angular/core';
+import {APP_INITIALIZER, LOCALE_ID, NgModule,} from '@angular/core';
 
-import { ToasterModule } from 'angular2-toaster';
+import {ToasterModule} from 'angular2-toaster';
 
-import { ElectronLogService } from 'jslib/electron/services/electronLog.service';
-import { ElectronPlatformUtilsService } from 'jslib/electron/services/electronPlatformUtils.service';
-import { ElectronRendererMessagingService } from 'jslib/electron/services/electronRendererMessaging.service';
-import { ElectronRendererSecureStorageService } from 'jslib/electron/services/electronRendererSecureStorage.service';
-import { ElectronStorageService } from 'jslib/electron/services/electronStorage.service';
-import { isDev } from 'jslib/electron/utils';
+import {ElectronLogService} from 'jslib/electron/services/electronLog.service';
+import {ElectronPlatformUtilsService} from 'jslib/electron/services/electronPlatformUtils.service';
+import {ElectronRendererMessagingService} from 'jslib/electron/services/electronRendererMessaging.service';
+import {ElectronRendererSecureStorageService} from 'jslib/electron/services/electronRendererSecureStorage.service';
+import {ElectronStorageService} from 'jslib/electron/services/electronStorage.service';
+import {isDev} from 'jslib/electron/utils';
 
-import { I18nService } from '../services/i18n.service';
+import {I18nService} from '../services/i18n.service';
 
-import { AuthGuardService } from 'jslib/angular/services/auth-guard.service';
-import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
-import { ValidationService } from 'jslib/angular/services/validation.service';
+import {AuthGuardService} from 'jslib/angular/services/auth-guard.service';
+import {BroadcasterService} from 'jslib/angular/services/broadcaster.service';
+import {ValidationService} from 'jslib/angular/services/validation.service';
 
-import { Analytics } from 'jslib/misc/analytics';
+import {Analytics} from 'jslib/misc/analytics';
 
-import { ApiService } from 'jslib/services/api.service';
-import { AppIdService } from 'jslib/services/appId.service';
-import { AuditService } from 'jslib/services/audit.service';
-import { AuthService } from 'jslib/services/auth.service';
-import { CipherService } from 'jslib/services/cipher.service';
-import { CollectionService } from 'jslib/services/collection.service';
-import { ConstantsService } from 'jslib/services/constants.service';
-import { ContainerService } from 'jslib/services/container.service';
-import { CryptoService } from 'jslib/services/crypto.service';
-import { EnvironmentService } from 'jslib/services/environment.service';
-import { ExportService } from 'jslib/services/export.service';
-import { FolderService } from 'jslib/services/folder.service';
-import { LockService } from 'jslib/services/lock.service';
-import { NotificationsService } from 'jslib/services/notifications.service';
-import { PasswordGenerationService } from 'jslib/services/passwordGeneration.service';
-import { SearchService } from 'jslib/services/search.service';
-import { SettingsService } from 'jslib/services/settings.service';
-import { StateService } from 'jslib/services/state.service';
-import { SyncService } from 'jslib/services/sync.service';
-import { SystemService } from 'jslib/services/system.service';
-import { TokenService } from 'jslib/services/token.service';
-import { TotpService } from 'jslib/services/totp.service';
-import { UserService } from 'jslib/services/user.service';
-import { WebCryptoFunctionService } from 'jslib/services/webCryptoFunction.service';
+import {ApiService} from 'jslib/services/api.service';
+import {AppIdService} from 'jslib/services/appId.service';
+import {AuditService} from 'jslib/services/audit.service';
+import {AuthService} from 'jslib/services/auth.service';
+import {AutoTypeService} from '../services/auto-type.service';
+import {CipherService} from 'jslib/services/cipher.service';
+import {CollectionService} from 'jslib/services/collection.service';
+import {ConstantsService} from 'jslib/services/constants.service';
+import {ContainerService} from 'jslib/services/container.service';
+import {CryptoService} from 'jslib/services/crypto.service';
+import {EnvironmentService} from 'jslib/services/environment.service';
+import {ExportService} from 'jslib/services/export.service';
+import {FolderService} from 'jslib/services/folder.service';
+import {LockService} from 'jslib/services/lock.service';
+import {NotificationsService} from 'jslib/services/notifications.service';
+import {PasswordGenerationService} from 'jslib/services/passwordGeneration.service';
+import {SearchService} from 'jslib/services/search.service';
+import {SettingsService} from 'jslib/services/settings.service';
+import {StateService} from 'jslib/services/state.service';
+import {SyncService} from 'jslib/services/sync.service';
+import {SystemService} from 'jslib/services/system.service';
+import {TokenService} from 'jslib/services/token.service';
+import {TotpService} from 'jslib/services/totp.service';
+import {UserService} from 'jslib/services/user.service';
+import {WebCryptoFunctionService} from 'jslib/services/webCryptoFunction.service';
 
-import { ApiService as ApiServiceAbstraction } from 'jslib/abstractions/api.service';
-import { AppIdService as AppIdServiceAbstraction } from 'jslib/abstractions/appId.service';
-import { AuditService as AuditServiceAbstraction } from 'jslib/abstractions/audit.service';
-import { AuthService as AuthServiceAbstraction } from 'jslib/abstractions/auth.service';
-import { CipherService as CipherServiceAbstraction } from 'jslib/abstractions/cipher.service';
-import { CollectionService as CollectionServiceAbstraction } from 'jslib/abstractions/collection.service';
-import { CryptoService as CryptoServiceAbstraction } from 'jslib/abstractions/crypto.service';
-import { CryptoFunctionService as CryptoFunctionServiceAbstraction } from 'jslib/abstractions/cryptoFunction.service';
-import { EnvironmentService as EnvironmentServiceAbstraction } from 'jslib/abstractions/environment.service';
-import { ExportService as ExportServiceAbstraction } from 'jslib/abstractions/export.service';
-import { FolderService as FolderServiceAbstraction } from 'jslib/abstractions/folder.service';
-import { I18nService as I18nServiceAbstraction } from 'jslib/abstractions/i18n.service';
-import { LockService as LockServiceAbstraction } from 'jslib/abstractions/lock.service';
-import { LogService as LogServiceAbstraction } from 'jslib/abstractions/log.service';
-import { MessagingService as MessagingServiceAbstraction } from 'jslib/abstractions/messaging.service';
-import { NotificationsService as NotificationsServiceAbstraction } from 'jslib/abstractions/notifications.service';
-import {
-    PasswordGenerationService as PasswordGenerationServiceAbstraction,
-} from 'jslib/abstractions/passwordGeneration.service';
-import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from 'jslib/abstractions/platformUtils.service';
-import { SearchService as SearchServiceAbstraction } from 'jslib/abstractions/search.service';
-import { SettingsService as SettingsServiceAbstraction } from 'jslib/abstractions/settings.service';
-import { StateService as StateServiceAbstraction } from 'jslib/abstractions/state.service';
-import { StorageService as StorageServiceAbstraction } from 'jslib/abstractions/storage.service';
-import { SyncService as SyncServiceAbstraction } from 'jslib/abstractions/sync.service';
-import { SystemService as SystemServiceAbstraction } from 'jslib/abstractions/system.service';
-import { TokenService as TokenServiceAbstraction } from 'jslib/abstractions/token.service';
-import { TotpService as TotpServiceAbstraction } from 'jslib/abstractions/totp.service';
-import { UserService as UserServiceAbstraction } from 'jslib/abstractions/user.service';
+import {AutoTypeService as AutoTypeServiceAbstraction} from 'jslib/abstractions';
+import {ApiService as ApiServiceAbstraction} from 'jslib/abstractions/api.service';
+import {AuditService as AuditServiceAbstraction} from 'jslib/abstractions/audit.service';
+import {AuthService as AuthServiceAbstraction} from 'jslib/abstractions/auth.service';
+import {CipherService as CipherServiceAbstraction} from 'jslib/abstractions/cipher.service';
+import {CollectionService as CollectionServiceAbstraction} from 'jslib/abstractions/collection.service';
+import {CryptoService as CryptoServiceAbstraction} from 'jslib/abstractions/crypto.service';
+import {CryptoFunctionService as CryptoFunctionServiceAbstraction} from 'jslib/abstractions/cryptoFunction.service';
+import {EnvironmentService as EnvironmentServiceAbstraction} from 'jslib/abstractions/environment.service';
+import {ExportService as ExportServiceAbstraction} from 'jslib/abstractions/export.service';
+import {FolderService as FolderServiceAbstraction} from 'jslib/abstractions/folder.service';
+import {I18nService as I18nServiceAbstraction} from 'jslib/abstractions/i18n.service';
+import {LockService as LockServiceAbstraction} from 'jslib/abstractions/lock.service';
+import {LogService as LogServiceAbstraction} from 'jslib/abstractions/log.service';
+import {MessagingService as MessagingServiceAbstraction} from 'jslib/abstractions/messaging.service';
+import {NotificationsService as NotificationsServiceAbstraction} from 'jslib/abstractions/notifications.service';
+import {PasswordGenerationService as PasswordGenerationServiceAbstraction,} from 'jslib/abstractions/passwordGeneration.service';
+import {PlatformUtilsService as PlatformUtilsServiceAbstraction} from 'jslib/abstractions/platformUtils.service';
+import {SearchService as SearchServiceAbstraction} from 'jslib/abstractions/search.service';
+import {SettingsService as SettingsServiceAbstraction} from 'jslib/abstractions/settings.service';
+import {StateService as StateServiceAbstraction} from 'jslib/abstractions/state.service';
+import {StorageService as StorageServiceAbstraction} from 'jslib/abstractions/storage.service';
+import {SyncService as SyncServiceAbstraction} from 'jslib/abstractions/sync.service';
+import {SystemService as SystemServiceAbstraction} from 'jslib/abstractions/system.service';
+import {TokenService as TokenServiceAbstraction} from 'jslib/abstractions/token.service';
+import {TotpService as TotpServiceAbstraction} from 'jslib/abstractions/totp.service';
+import {UserService as UserServiceAbstraction} from 'jslib/abstractions/user.service';
 
 const logService = new ElectronLogService();
 const i18nService = new I18nService(window.navigator.language, './locales');
@@ -118,7 +113,8 @@ const notificationsService = new NotificationsService(userService, syncService, 
     apiService, lockService, async () => messagingService.send('logout', { expired: true }));
 const environmentService = new EnvironmentService(apiService, storageService, notificationsService);
 const systemService = new SystemService(storageService, lockService, messagingService, platformUtilsService, null);
-
+const autoTypeService = new AutoTypeService(storageService, cipherService,
+    platformUtilsService, messagingService, passwordGenerationService);
 const analytics = new Analytics(window, () => isDev(), platformUtilsService, storageService, appIdService);
 containerService.attachToGlobal(window);
 
@@ -171,6 +167,7 @@ export function initFactory(): Function {
         AuthGuardService,
         { provide: AuditServiceAbstraction, useValue: auditService },
         { provide: AuthServiceAbstraction, useValue: authService },
+        { provide: AutoTypeServiceAbstraction, useValue: autoTypeService },
         { provide: CipherServiceAbstraction, useValue: cipherService },
         { provide: FolderServiceAbstraction, useValue: folderService },
         { provide: CollectionServiceAbstraction, useValue: collectionService },

--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -260,6 +260,54 @@
             </div>
             <div class="box">
                 <div class="box-header">
+                    {{'autoTypeTargets' | i18n}}
+                </div>
+                <div class="box-content">
+                    <div class="box-content-row box-content-row-checkbox" appBoxRow>
+                        <label for="enableAutoType">{{'enableAutoType' | i18n}}</label>
+                        <input id="enableAutoType" type="checkbox" name="EnableAutoType" [(ngModel)]="cipher.enableAutoType">
+                    </div>
+                    <div cdkDropList (cdkDropListDropped)="drop($event)" *ngIf="cipher.hasAutoTypeTargets">
+                        <div class="box-content-row box-content-row-multi box-draggable-row" cdkDrag
+                             *ngFor="let f of cipher.autoTypeTargets; let i = index; trackBy:trackByFunction">
+                            <a href="#" appStopClick (click)="removeAutoTypeTarget(f)" appA11yTitle="{{'remove' | i18n}}"
+                               role="button">
+                                <i class="fa fa-minus-circle fa-lg" aria-hidden="true"></i>
+                            </a>
+                            <label for="autoTypeTarget{{i}}" class="sr-only">{{'autoTypeTarget' | i18n}}</label>
+                            <label for="autoTypeSequence{{i}}" class="sr-only">{{'autoTypeSequence' | i18n}}</label>
+                            <div class="row-main">
+                                <input id="autoTypeTarget{{i}}" type="text" name="AutoType.Target{{i}}" [(ngModel)]="f.target"
+                                       class="row-label" placeholder="{{'autoTypeTarget' | i18n}}" list="autoTypeTargets">
+                                <input id="autoTypeSequence{{i}}" type="text" name="AutoType.Sequence{{i}}" [(ngModel)]="f.sequence"
+                                       placeholder="{{'autoTypeSequence' | i18n}}">
+                            </div>
+                            <label for="autoTypeTCATO{{i}}" class="sr-only">{{'autoTypeTCATO' | i18n}}</label>
+                            <input id="autoTypeTCATO{{i}}" name="AutoType.TCATO{{i}}" type="checkbox" [(ngModel)]="f.tcato"
+                                   appTrueFalseValue trueValue="true" falseValue="false">
+                            <div class="action-buttons">
+                                <a class="row-btn" href="#" appStopClick appBlurClick role="button"
+                                   appA11yTitle="{{'selectAutoTypeTarget' | i18n}}" (click)="selectTarget(f)">
+                                    <i class="fa fa-lg fa-window-restore" aria-hidden="true"></i>
+                                </a>
+                            </div>
+                            <div class="drag-handle" appA11yTitle="{{'dragToSort' | i18n}}" cdkDragHandle>
+                                <i class="fa fa-bars" aria-hidden="true"></i>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="box-content-row" appBoxRow>
+                        <a href="#" appStopClick (click)="addAutoTypeTarget()" role="button">
+                            <i class="fa fa-plus-circle fa-fw fa-lg" aria-hidden="true"></i> {{'newAutoTypeTarget' | i18n}}
+                        </a>
+                    </div>
+                </div>
+                <datalist id="autoTypeTargets">
+                    <option *ngFor="let item of getPossibleTargets()" [value]="item">
+                </datalist>
+            </div>
+            <div class="box">
+                <div class="box-header">
                     {{'customFields' | i18n}}
                 </div>
                 <div class="box-content">

--- a/src/app/vault/add-edit.component.ts
+++ b/src/app/vault/add-edit.component.ts
@@ -1,19 +1,17 @@
-import {
-    Component,
-    OnChanges,
-} from '@angular/core';
+import {Component, OnChanges,} from '@angular/core';
 
-import { AuditService } from 'jslib/abstractions/audit.service';
-import { CipherService } from 'jslib/abstractions/cipher.service';
-import { CollectionService } from 'jslib/abstractions/collection.service';
-import { FolderService } from 'jslib/abstractions/folder.service';
-import { I18nService } from 'jslib/abstractions/i18n.service';
-import { MessagingService } from 'jslib/abstractions/messaging.service';
-import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
-import { StateService } from 'jslib/abstractions/state.service';
-import { UserService } from 'jslib/abstractions/user.service';
+import {AuditService} from 'jslib/abstractions/audit.service';
+import {AutoTypeService} from 'jslib/abstractions/auto-type.service';
+import {CipherService} from 'jslib/abstractions/cipher.service';
+import {CollectionService} from 'jslib/abstractions/collection.service';
+import {FolderService} from 'jslib/abstractions/folder.service';
+import {I18nService} from 'jslib/abstractions/i18n.service';
+import {MessagingService} from 'jslib/abstractions/messaging.service';
+import {PlatformUtilsService} from 'jslib/abstractions/platformUtils.service';
+import {StateService} from 'jslib/abstractions/state.service';
+import {UserService} from 'jslib/abstractions/user.service';
 
-import { AddEditComponent as BaseAddEditComponent } from 'jslib/angular/components/add-edit.component';
+import {AddEditComponent as BaseAddEditComponent} from 'jslib/angular/components/add-edit.component';
 
 @Component({
     selector: 'app-vault-add-edit',
@@ -24,9 +22,9 @@ export class AddEditComponent extends BaseAddEditComponent implements OnChanges 
         i18nService: I18nService, platformUtilsService: PlatformUtilsService,
         auditService: AuditService, stateService: StateService,
         userService: UserService, collectionService: CollectionService,
-        messagingService: MessagingService) {
+        messagingService: MessagingService, autoTypeService: AutoTypeService) {
         super(cipherService, folderService, i18nService, platformUtilsService, auditService, stateService,
-            userService, collectionService, messagingService);
+            userService, collectionService, messagingService, autoTypeService);
     }
 
     async ngOnInit() {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -105,6 +105,42 @@
   "customFields": {
     "message": "Custom Fields"
   },
+  "autoType": {
+    "message": "Auto-type"
+  },
+  "autoTypeTargets": {
+    "message": "Auto-Type Targets"
+  },
+  "globalKeyboardShortcut": {
+    "message": "Global Keyboard Shortcut"
+  },
+  "globalKeyboardShortcutHelp": {
+    "message": "WRITE ME!"
+  },
+  "autoTypeDefaultSequence": {
+    "message": "Default sequence"
+  },
+  "autoTypeSequenceHelp": {
+    "message": "WRITE ME!"
+  },
+  "newAutoTypeTarget": {
+    "message": "New auto-type target"
+  },
+  "enableAutoType": {
+    "message": "Enable auto-type"
+  },
+  "autoTypeTarget": {
+    "message": "Target"
+  },
+  "selectAutoTypeTarget": {
+    "message": "Select target"
+  },
+  "autoTypeSequence": {
+    "message": "Sequence"
+  },
+  "autoTypeTCATO": {
+    "message": "Two-Channel Auto-Type Obfuscation"
+  },
   "launch": {
     "message": "Launch"
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,28 +1,30 @@
-import { app } from 'electron';
+import {app} from 'electron';
 import * as path from 'path';
 
-import { I18nService } from './services/i18n.service';
+import {I18nService} from './services/i18n.service';
 
-import { MenuMain } from './main/menu.main';
-import { MessagingMain } from './main/messaging.main';
-import { PowerMonitorMain } from './main/powerMonitor.main';
+import {MenuMain} from './main/menu.main';
+import {MessagingMain} from './main/messaging.main';
+import {PowerMonitorMain} from './main/powerMonitor.main';
 
-import { ConstantsService } from 'jslib/services/constants.service';
+import {ConstantsService} from 'jslib/services/constants.service';
 
-import { ElectronConstants } from 'jslib/electron/electronConstants';
-import { KeytarStorageListener } from 'jslib/electron/keytarStorageListener';
-import { ElectronLogService } from 'jslib/electron/services/electronLog.service';
-import { ElectronMainMessagingService } from 'jslib/electron/services/electronMainMessaging.service';
-import { ElectronStorageService } from 'jslib/electron/services/electronStorage.service';
-import { TrayMain } from 'jslib/electron/tray.main';
-import { UpdaterMain } from 'jslib/electron/updater.main';
-import { WindowMain } from 'jslib/electron/window.main';
+import {ElectronConstants} from 'jslib/electron/electronConstants';
+import {KeytarStorageListener} from 'jslib/electron/keytarStorageListener';
+import {ElectronLogService} from 'jslib/electron/services/electronLog.service';
+import {ElectronMainMessagingService} from 'jslib/electron/services/electronMainMessaging.service';
+import {ElectronStorageService} from 'jslib/electron/services/electronStorage.service';
+import {TrayMain} from 'jslib/electron/tray.main';
+import {UpdaterMain} from 'jslib/electron/updater.main';
+import {WindowMain} from 'jslib/electron/window.main';
+import {AutoTypeService} from './services/auto-type.service';
 
 export class Main {
     logService: ElectronLogService;
     i18nService: I18nService;
     storageService: ElectronStorageService;
     messagingService: ElectronMainMessagingService;
+    autoTypeService: AutoTypeService;
     keytarStorageListener: KeytarStorageListener;
 
     windowMain: WindowMain;
@@ -80,6 +82,8 @@ export class Main {
         this.messagingService = new ElectronMainMessagingService(this.windowMain, (message) => {
             this.messagingMain.onMessage(message);
         });
+
+        //this.autoTypeService = new AutoTypeService(this.storageService, );
 
         this.keytarStorageListener = new KeytarStorageListener('Bitwarden');
     }

--- a/src/main/messaging.main.ts
+++ b/src/main/messaging.main.ts
@@ -1,6 +1,6 @@
-import { ipcMain } from 'electron';
+import {ipcMain} from 'electron';
 
-import { Main } from '../main';
+import {Main} from '../main';
 
 const SyncInterval = 5 * 60 * 1000; // 5 minutes
 
@@ -31,6 +31,13 @@ export class MessagingMain {
                 break;
             case 'hideToTray':
                 this.main.trayMain.hideToTray();
+                break;
+            case 'showWindow':
+                this.main.windowMain.win.show();  // TODO More work needs to be done to abstract showing the window.
+                                      // Code is sprinkled everywere that does this and there are issues if win == null.
+                break;
+            case 'updateAutoTypeHotkey':
+                this.main.autoTypeService.update();
                 break;
             default:
                 break;

--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,9 @@
     "electron-log": "2.2.17",
     "electron-store": "1.3.0",
     "electron-updater": "4.0.6",
-    "keytar": "4.4.1"
+    "keytar": "4.4.1",
+    "robotjs": "latest",
+    "string.prototype.matchall": "latest",
+    "node-window-manager": "latest"
   }
 }

--- a/src/services/auto-type.service.ts
+++ b/src/services/auto-type.service.ts
@@ -1,0 +1,936 @@
+/**
+ * Autotype Service
+ *
+ * Classes:
+ *
+ *
+ * Enums:
+ * Robokeys
+ *
+ * Methods:
+ * keyboardEventToAccelerator()
+ * beep()
+ * resolvePlaceholder()
+ */
+// @ts-ignore
+import process from 'child_process';
+import { app, globalShortcut } from 'electron';
+import {
+    AutoTypeService as AutoTypeServiceBase,
+    CipherService,
+    MessagingService,
+    PasswordGenerationService,
+    PlatformUtilsService,
+    StorageService,
+} from 'jslib/abstractions';
+import { ElectronConstants } from 'jslib/electron/electronConstants';
+import { DeviceType } from 'jslib/enums';
+import { Cipher } from 'jslib/models/domain';
+import { CipherView, FieldView } from 'jslib/models/view';
+import { AutoTypeView } from 'jslib/models/view/autoTypeView';
+import { Window, windowManager } from 'node-window-manager'; // https://github.com/sentialx/node-window-manager
+import { EOL } from 'os';
+// @ts-ignore
+import path from 'path';
+// @ts-ignore
+import robot from 'robotjs';
+// Shim the missing matchall string function. TODO Remove me for ECMAScript 2020
+// @ts-ignore
+import matchAll from 'string.prototype.matchall';
+declare global {
+    // tslint:disable-next-line:interface-name
+    interface RegExpStringIterator {
+        next: () => {value: RegExpMatchArray, done: boolean};
+        [Symbol.iterator]: () => RegExpStringIterator;
+    }
+    // tslint:disable-next-line:interface-name
+    interface String {
+        matchAll: (regexp: RegExp) => RegExpStringIterator;
+    }
+}
+matchAll.shim();
+
+// electron.globalShortcut supported keys
+const digits = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+const supportedKeys = [
+    ...digits,
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
+    'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+    'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12',
+    'F13', 'F14', 'F15', 'F16', 'F17', 'F18', 'F19', 'F20', 'F21', 'F22', 'F23', 'F24',
+    '~', '!', '@', '#', '$', '%', '^', '&', '*', '(', ')', '_', '+', '{', '}', '|',
+    '?', '>', '<', '`', '-', '=', '[', ']', '\\', ';', '\'', ',', '.', '/',
+    'Plus', 'Space', 'Tab', 'Capslock', 'Numlock', 'Backspace', 'Delete', 'Insert', 'Return', 'Scrolllock',
+    'Up', 'Down', 'Left', 'Right', 'Home', 'End', 'PageUp', 'PageDown', 'Escape', 'PrintScreen',
+    'VolumeUp', 'VolumeDown', 'VolumeMute', 'MediaNextTrack', 'MediaPreviousTrack', 'MediaStop', 'MediaPlayPause',
+    'numdec', 'numadd', 'numsub', 'nummult', 'numdiv',
+    'num0', 'num1', 'num2', 'num3', 'num4', 'num5', 'num6', 'num7', 'num8', 'num9',
+];
+
+// KeyboardEvent key location constants
+const DOM_KEY_LOCATION_STANDARD = 0;
+const DOM_KEY_LOCATION_LEFT = 1;
+const DOM_KEY_LOCATION_RIGHT = 2;
+const DOM_KEY_LOCATION_NUMPAD = 3;
+
+/**
+ * Convert a KeyboardEvent to an accelerator string required by electron.globalShortcut
+ * @param event KeyboardEvent instance
+ */
+export function keyboardEventToAccelerator(event: KeyboardEvent): string {
+    const keys = [];
+    if (event.metaKey) {
+        keys.push('Super');
+    }
+    if (event.altKey) {
+        if (event.location === DOM_KEY_LOCATION_RIGHT) {
+            keys.push('AltGr');
+        } else {
+            keys.push('Alt');
+        }
+    }
+    if (event.ctrlKey) {
+        keys.push('CommandOrControl');
+    }
+    if (event.shiftKey) {
+        keys.push('Shift');
+    }
+    let key = null;
+    switch (event.key) {
+        case '.':
+            if (event.location === DOM_KEY_LOCATION_NUMPAD) {
+                key = 'numdec';
+            } else {
+                key = event.key;
+            }
+            break;
+        case '-':
+            if (event.location === DOM_KEY_LOCATION_NUMPAD) {
+                key = 'numsub';
+            } else {
+                key = event.key;
+            }
+            break;
+        case '/':
+            if (event.location === DOM_KEY_LOCATION_NUMPAD) {
+                key = 'numdiv';
+            } else {
+                key = event.key;
+            }
+            break;
+        case '*':
+            if (event.location === DOM_KEY_LOCATION_NUMPAD) {
+                key = 'nummult';
+            } else {
+                key = event.key;
+            }
+            break;
+        case '+':
+            if (event.location === DOM_KEY_LOCATION_NUMPAD) {
+                key = 'numadd';
+            } else {
+                key = 'Plus';
+            }
+            break;
+        case ' ':
+            key = 'Space';
+            break;
+        case 'ArrowUp':
+        case 'ArrowDown':
+        case 'ArrowLeft':
+        case 'ArrowRight':
+            key = event.key.substr(5);
+            break;
+        case 'PageUp':
+        case 'PageDown':
+            key = event.key;
+            break;
+        default:
+            key = event.key.charAt(0).toUpperCase() + event.key.toLowerCase().slice(1);
+            break;
+    }
+    if (event.location === DOM_KEY_LOCATION_NUMPAD && digits.includes(key)) { key = 'num' + key; }
+    if (!supportedKeys.includes(key)) { return ''; }
+    keys.push(key);
+    return keys.join('+');
+}
+
+// Patterns for Keepass placeholders
+const placeholderPattern = new RegExp(
+    '{(T-REPLACE-RX):(.)(.+?)\\2(.+?)\\2(.+?)\\2}' +
+    '|{(T-CONV|CMD):(.)(.+?)\\7(.+?)\\7}' +
+    '|{(NEWPASSWORD)(?::(.)(.+?)\\11)?}' +
+    '|{(REF):([TUPANIO])@([TUPANIO]):([^}]+)}' +
+    '|{(PICKCHARS)(?::([^:}]+)(?::([^}]+))?)?}' +
+    '|{(C):([^}]*)}' +
+    '|{(DELAY=)([^}]+)}' +
+    '|{([^:} ]+)(?:[: ]([^}]+))?}',
+    'gi',
+);
+
+// Used by {REF: }
+const searchPattern = new RegExp('(-)?(?:(["\'])(.+?)\\2|[^"\' ]+)', 'g');
+
+// Used by {CMD: }
+const cmdPattern = new RegExp('(M|O|W|WS|V)=([^,]+)', 'g');
+
+// Keys supported by robotjs
+enum RoboKeys {
+    backspace, delete, enter, tab, escape, up, down, right, left, home, end, pageup, pagedown,
+    f1, f2, f3, f4, f5, f6, f7, f8, f9, f10, f11, f12, command, alt, control, shift, right_shift,
+    space, printscreen, insert, audio_mute, audio_vol_down, audio_vol_up, audio_play, audio_stop, audio_pause,
+    audio_prev, audio_next, audio_rewind, audio_forward, audio_repeat, audio_random,
+    numpad_0, numpad_1, numpad_2, numpad_3, numpad_4, numpad_5, numpad_6, numpad_7, numpad_8, numpad_9,
+    lights_mon_up, lights_mon_down, lights_kbd_toggle, lights_kbd_up, lights_kbd_down,
+}
+
+/**
+ * Play a tone for a duration
+ * @param freq Frequency in Hz
+ * @param duration Duration in milliseconds
+ */
+function beep(freq: number, duration: number) {
+    const context = new AudioContext();
+    const o = context.createOscillator();
+    const g = context.createGain();
+    o.connect(g);
+    g.connect(context.destination);
+    o.frequency.value = freq;
+    o.start();
+    o.stop(context.currentTime + (duration / 1000));
+}
+
+function matchToArgs(match: RegExpMatchArray): [string, ...string[]] {
+    const index = match.findIndex((val: string, i: number) => (i > 0 && val !== ''));
+    return [match[index], ...match.slice(index + 1)];
+}
+
+export class AutoTypeService implements AutoTypeServiceBase {
+    private readonly systemClipModifier: string;
+
+    constructor(private storageService: StorageService, private cipherService: CipherService,
+                private platformUtilsService: PlatformUtilsService, private messagingService: MessagingService,
+                private passwordGenerationService: PasswordGenerationService) {
+        this.systemClipModifier =
+            this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop ? 'command' : 'ctrl';
+    }
+
+    init() {
+        app.on('will-quit', () => {
+            // Unregister all shortcuts.
+            globalShortcut.unregisterAll();
+        });
+        app.on('ready', () => {
+            // Register auto-type hotkey
+            this.update();
+        });
+    }
+
+    update() {
+        globalShortcut.unregisterAll();
+        this.storageService.get<string>(ElectronConstants.enableAutoTypeKey).then((enabled) => {
+            if (enabled) {
+                this.storageService.get<string>(ElectronConstants.AutoTypeHotkeyKey).then(
+                    (accelerator) => {
+                        if (accelerator) {
+                            globalShortcut.register(accelerator, () => {
+                                this.typeTarget();
+                            });
+
+                            if (!globalShortcut.isRegistered(accelerator)) {
+                                throw new Error('Failed to register auto-type hotkey.');
+                            }
+                        }
+                    });
+            }
+        });
+    }
+
+    async getTarget(): Promise<string> {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(reject, 10000, 'Took too long to select a window');
+            windowManager.once('window-activated', (window: Window) => {
+                clearTimeout(timer);
+                resolve(window.getTitle());
+            });
+        });
+    }
+
+    getPossibleTargets(): string[] {
+        return windowManager.getWindows().map((w: Window) => w.getTitle());
+    }
+
+    typeUsingClip(str: string) {
+        if (str.length === 0) { return; }
+        this.platformUtilsService.copyToClipboard(str);
+        robot.keyTap('v', this.systemClipModifier);
+    }
+
+    async typeTarget() {
+        const target = await this.getTarget();
+
+        // Get candidate targets
+        const candidates = [];
+        const ciphers = await this.cipherService.getAll();
+        for (const cipher of ciphers) {
+            if (cipher.enableAutoType) {
+                const decCipher = await cipher.decrypt();
+                for (const targetCandidate of decCipher.autoTypeTargets) {
+                    const match = target.match(targetCandidate.target);
+                    if (match[0].length) {
+                        candidates.push({match: match, target: targetCandidate, cipher: cipher, decCipher: decCipher});
+                    }
+                }
+            }
+        }
+
+        // Decide on final candidate
+        let candidate: {match: RegExpMatchArray, target: AutoTypeView, cipher: Cipher, decCipher: CipherView} = null;
+        if (candidates.length === 1) {
+            candidate = candidates[0];
+        } else if (candidates.length > 1) {
+            candidates.sort((a, b) => b.match.length - a.match.length);
+            candidate = candidates[0]; // TODO show context menu to pick candidate
+        } else {
+            return false; // candidate will never be null past this point
+        }
+
+        // TODO switch to typing codes to add support for more keys
+        //  when https://github.com/octalmage/robotjs/pull/357 is merged
+
+        // Use same time across all placeholders
+        const now = new Date(Date.now());
+
+        // Replace placeholders
+        const placeholders = await Promise.all<Array<string | RoboKeys | (() => Promise<string>)>>(
+            Array.from(candidate.target.sequence.matchAll(placeholderPattern), (match: RegExpMatchArray) => {
+                return this.resolvePlaceholder(
+                    candidate.decCipher,
+                    candidate.cipher,
+                    ciphers,
+                    now,
+                    ...matchToArgs(match),
+                );
+            }),
+        );
+
+        // Don't clobber current clipboard content
+        const oldClip = await this.platformUtilsService.readFromClipboard();
+
+        // Execute sequence
+        let modifier: string[] = [];
+        for (const placeholder of placeholders) {
+            for (let element of placeholder) {
+                // Break up strings containing modifiers or special keys
+                switch (typeof element) {
+                    case 'number':
+                        robot.keyTap(RoboKeys[element], modifier);
+                        modifier = [];
+                        break;
+                    case 'function':
+                        element = await element();
+                        // fall through
+                    case 'string':
+                        if (element.length > 1) {
+                            let clip = '';
+                            const median = element.split('')
+                                .sort((a: string, b: string) => a.localeCompare(b))[Math.floor(element.length / 2)];
+                            for (let i = 0; i < element.length; ++i) {
+                                // Handle special keys
+                                if ('+^%~ '.includes(element[i])) {
+                                    // Not compatible with clip board, push existing clipboard
+                                    this.typeUsingClip(clip);
+                                    clip = '';
+                                    switch (element[i]) {
+                                        case '+':
+                                            modifier.push(RoboKeys[RoboKeys.shift]);
+                                            break;
+                                        case '^':
+                                            modifier.push(RoboKeys[RoboKeys.control]);
+                                            break;
+                                        case '%':
+                                            modifier.push(RoboKeys[RoboKeys.alt]);
+                                            break;
+                                        case '~':
+                                            robot.keyTap(RoboKeys[RoboKeys.enter], modifier);
+                                            modifier = [];
+                                            break;
+                                        case ' ':
+                                            robot.keyTap(RoboKeys[RoboKeys.space], modifier);
+                                            modifier = [];
+                                            break;
+                                    }
+                                    continue;
+                                }
+                                if (candidate.target.tcato && modifier.length === 0) {
+                                    // Split sequence into tcato chunks
+                                    // Compare to median letter so that half of the string ends up in the clipboard
+                                    // but which letters are chosen vary from string to string
+                                    if (element[i].localeCompare(median) < 0) {
+                                        clip += element[i];
+                                    } else {
+                                        this.typeUsingClip(clip);
+                                        clip = '';
+                                        robot.keyTap(element[i], modifier);
+                                        modifier = [];
+                                    }
+                                } else {
+                                    robot.keyTap(element[i], modifier);
+                                    modifier = [];
+                                }
+                            }
+                            if (clip.length > 0) {
+                                this.typeUsingClip(clip);
+                                clip = '';
+                            }
+                        } else if (element.length > 0) {
+                            robot.keyTap(element, modifier);
+                            modifier = [];
+                        }
+                        break;
+                }
+            }
+        }
+
+        // this.platformUtilsService.copyToClipboard(seq);
+        this.platformUtilsService.copyToClipboard(oldClip);
+    }
+
+    /**
+     * Make a best attempt to convert the placeholders to a string
+     * This is used when a placeholder requires another placeholder to be a string in order to resolve
+     * @param placeholders Array of placeholders
+     */
+    async flattenPlaceholders(placeholders: Array<string | RoboKeys | (() => Promise<string>)>): Promise<string> {
+        for (let i = 0; i < placeholders.length; ++i) {
+            const placeholder = placeholders[i];
+            if (typeof placeholder === 'function') {
+                placeholders[i] = await placeholder();
+            } else if (typeof placeholder !== 'string') {
+                switch (placeholder) {
+                    case RoboKeys.enter:
+                        placeholders[i] = EOL;
+                        break;
+                    case RoboKeys.space:
+                        placeholders[i] = ' ';
+                        break;
+                    case RoboKeys.tab:
+                        placeholders[i] = '\t';
+                        break;
+                    default:
+                        const name = RoboKeys[placeholder];
+                        if (name.startsWith('numpad_')) {
+                            placeholders[i] = name.charAt(name.length - 1);
+                            break;
+                        }
+                        placeholders[i] = '';
+                        break;
+                }
+            }
+        }
+        return placeholders.join('');
+    }
+
+    /**
+     * Resolve placeholders matched by placeholderPattern
+     * See https://keepass.info/help/base/placeholders.html
+     * If a function is returned, the function must return a string
+     * @param decCipher decrypted instance of cipher param
+     * @param cipher Cipher instance to refer to when resolving placeholder
+     * @param ciphers Array of ciphers to refer to when searching for value
+     * @param now instance of Date representing current date-time
+     * @param placeholder Name of placeholder
+     * @param args Capture groups of placeholderPattern
+     * @return Hetergoenous array of strings, Robokeys, and callables representing the placeholders function or result
+     */
+    async resolvePlaceholder(
+        decCipher: CipherView,
+        cipher: Cipher,
+        ciphers: Cipher[],
+        now: Date,
+        placeholder: string,
+        ...args: string[]
+    ): Promise<Array<string | RoboKeys | (() => Promise<string>)>> {
+        const param = args.length ? args[0] : '';
+        switch (placeholder.toUpperCase()) {
+            case 'T-REPLACE-RX': {
+                const [text, pattern, replace] = args;
+                let flatText = '';
+                let flatPattern = '';
+                let flatReplace = '';
+                // Each param can contain placeholders
+                for (const match of text.matchAll(placeholderPattern)) {
+                    flatText += await this.flattenPlaceholders(
+                        await this.resolvePlaceholder(decCipher, cipher, ciphers, now, ...matchToArgs(match)),
+                    );
+                }
+                for (const match of pattern.matchAll(placeholderPattern)) {
+                    flatPattern += await this.flattenPlaceholders(
+                        await this.resolvePlaceholder(decCipher, cipher, ciphers, now, ...matchToArgs(match)),
+                    );
+                }
+                for (const match of replace.matchAll(placeholderPattern)) {
+                    flatReplace += await this.flattenPlaceholders(
+                        await this.resolvePlaceholder(decCipher, cipher, ciphers, now, ...matchToArgs(match)),
+                    );
+                }
+                flatText = flatText.replace(flatPattern, flatReplace);
+                return [flatText];
+            }
+            case 'T-CONV': {
+                const [text, type] = args;
+                let flatText = '';
+                for (const match of text.matchAll(placeholderPattern)) {
+                    flatText += await this.flattenPlaceholders(
+                        await this.resolvePlaceholder(decCipher, cipher, ciphers, now, ...matchToArgs(match)),
+                    );
+                }
+                switch (type.toUpperCase()) {
+                    case 'UPPER':
+                    case 'U':
+                        flatText = flatText.toUpperCase();
+                        break;
+                    case 'LOWER':
+                    case 'L':
+                        flatText = flatText.toLowerCase();
+                        break;
+                    case 'BASE64':
+                        flatText = btoa(flatText);
+                        break;
+                    case 'HEX':
+                        try {
+                            flatText = flatText.split('').map((v: string) =>
+                                v.charCodeAt(0).toString(16),
+                            ).join('');
+                        } catch (e) {
+                            flatText = '';
+                        }
+                        break;
+                    case 'URI':
+                        flatText = encodeURIComponent(flatText);
+                        break;
+                    case 'URI-DEC':
+                        flatText = decodeURIComponent(flatText);
+                        break;
+                    case 'RAW':
+                        const text2 = flatText;
+                        flatText = '';
+                        for (const match of text2.matchAll(placeholderPattern)) {
+                            flatText += await this.flattenPlaceholders(
+                                await this.resolvePlaceholder(decCipher, cipher, ciphers, now, ...matchToArgs(match)),
+                            );
+                        }
+                        break;
+                }
+                return [flatText];
+            }
+            case 'CMD': {
+                const [command, options] = args;
+                let wait = false;
+                let output = true;
+                const opt = {
+                    shell: true,
+                    hide: true,
+                };
+                for (const [_, o, val] of options.matchAll(cmdPattern)) {
+                    switch (o) {
+                        case 'M':
+                            opt.shell = val !== 'C';
+                            break;
+                        case 'O':
+                            output = val === '1';
+                            break;
+                        case 'W':
+                            wait = val === '1';
+                            break;
+                        case 'WS':
+                            opt.hide = val === 'H';
+                            break;
+                        case 'V':
+                            // Admin not supported, use a script to elevate.
+                            break;
+                    }
+                }
+
+                if (!command) { return []; }
+                if (wait && !output) {
+                    return [process.execSync(command, opt)];
+                } else {
+                    process.exec(command, opt);
+                    return [];
+                }
+            }
+            case 'NEWPASSWORD': {
+                const profile = param;
+                switch (profile) { // TODO need to build better password generators like keepass
+                    case 'phrase':
+                        return [await this.passwordGenerationService.generatePassphrase({})];
+                    case 'word':
+                    default:
+                        return [await this.passwordGenerationService.generatePassword({})];
+                }
+            }
+            case 'PICKCHARS': {
+                const [field, opt] = args;
+                // TODO need modal
+                return [];
+            }
+            case 'C':
+                // const comment = param;
+                return [];
+            case 'S':
+                // Custom strings can be referenced using {S:Name}.
+                const result = decCipher.fields.find((f: FieldView) => f.name === param);
+                if (result) {
+                    return [result.value];
+                } else {
+                    return [];
+                }
+            case 'REF':
+                // https://keepass.info/help/base/fieldrefs.html
+                const [wanted, search, query] = args;
+                const queryItems = query.matchAll(searchPattern);
+
+                let found = null;
+                cipher: for (const c of ciphers) {
+                    const values = [];
+                    switch (search) {
+                        case 'T':
+                            // T	Title
+                            values.push(await c.name.decrypt(c.organizationId));
+                            break;
+                        case 'U':
+                            // U	User name
+                            values.push(await c.login.username.decrypt(c.organizationId));
+                            break;
+                        case 'P':
+                            // P	Password
+                            values.push(await c.login.password.decrypt(c.organizationId));
+                            break;
+                        case 'A':
+                            // A	URL
+                            for (const uri of c.login.uris) {
+                                values.push((await uri.decrypt(c.organizationId)).uri);
+                            }
+                            break;
+                        case 'N':
+                            // N	Notes
+                            values.push(await c.notes.decrypt(c.organizationId));
+                            break;
+                        case 'I':
+                            // I	UUID
+                            values.push(c.id);
+                            break;
+                        case 'O':
+                            // O	Other custom strings
+                            for (const f of c.fields) {
+                                const decField = await f.decrypt(c.organizationId);
+                                values.push(decField.name);
+                                values.push(decField.value);
+                            }
+                            break;
+                        default:
+                            return [];
+                    }
+                    for (const value of values) {
+                        for (const [_, neg, item] of queryItems) {
+                            if (value.includes(item) === (neg === '-')) { // ~XOR
+                                continue cipher;
+                            }
+                        }
+                    }
+                    found = c;
+                    break;
+                }
+                if (found === null) {
+                    return [];
+                }
+                switch (wanted) {
+                    case 'T':
+                        // T	Title
+                        return [await found.name.decrypt(found.organizationId)];
+                    case 'U':
+                        // U	User name
+                        return [await found.login.username.decrypt(found.organizationId)];
+                    case 'P':
+                        // P	Password
+                        return [await found.login.password.decrypt(found.organizationId)];
+                    case 'A':
+                        // A	URL
+                        for (const uri of found.login.uris) { // TODO should there be better criteria than first uri?
+                            return [(await uri.decrypt(found.organizationId)).uri];
+                        }
+                        return [];
+                    case 'N':
+                        // N	Notes
+                        return [await found.notes.decrypt(found.organizationId)];
+                    case 'I':
+                        // I	UUID
+                        return [found.id];
+                    case 'O':
+                    default:
+                        return [];
+                }
+            case 'TITLE':
+                return [decCipher.name];
+            case 'USERNAME':
+                return [decCipher.login.username];
+            case 'PASSWORD':
+                return [decCipher.login.password];
+            case 'NOTES':
+                return [decCipher.notes];
+            case 'URL':
+            case 'BASE': {
+                const uri = new URL(decCipher.login.uri);
+                switch (param) {
+                    case 'RMVSCM':
+                        if (uri.protocol) {
+                            return [uri.href.substr(uri.protocol.length)];
+                        } else {
+                            return [uri.href];
+                        }
+                    case 'SCM':
+                        return [uri.protocol];
+                    case 'HOST':
+                        return [uri.hostname];
+                    case 'PORT':
+                        return [uri.port];
+                    case 'PATH':
+                        return [uri.pathname];
+                    case 'QUERY':
+                        return [uri.search];
+                    case 'USERINFO':
+                        return [uri.username + ':' + uri.password];
+                    case 'USERNAME':
+                        return [uri.username];
+                    case 'PASSWORD':
+                        return [uri.password];
+                    default:
+                        return [uri.href];
+                }
+            }
+            case 'INTERNETEXPLORER':
+                return []; // Not supported
+            case 'FIREFOX':
+                return []; // Not supported
+            case 'OPERA':
+                return []; // Not supported
+            case 'GOOGLECHROME':
+                return []; // Not supported
+            case 'SAFARI':
+                return []; // Not supported
+            case 'APPDIR':
+                return []; // Not supported?
+            case 'GROUP':
+                return [decCipher.folderId];
+            case 'GROUP_PATH':
+                return []; // Not supported
+            case 'GROUP_NOTES':
+                return []; // Not supported
+            case 'GROUP_SEL':
+                return []; // TODO need to locate where current selected folder is stored in code
+            case 'GROUP_SEL_PATH':
+                return []; // Not supported
+            case 'GROUP_SEL_NOTES':
+                return []; // Not supported
+            case 'DB_PATH':
+                return []; // Not supported
+            case 'DB_DIR':
+                return []; // Not supported
+            case 'DB_NAME':
+                return []; // Not supported
+            case 'DB_BASENAME':
+                return []; // Not supported
+            case 'DB_EXT':
+                return []; // Not supported
+            case 'ENV_DIRSEP':
+                return [path.sep];
+            case 'ENV_PROGRAMFILES_X86':
+                return []; // TODO need to wrangle env variables
+            case 'DT_SIMPLE':
+                return [[
+                    now.getFullYear(), now.getMonth(), now.getDay(),
+                    now.getHours(), now.getMinutes(), now.getSeconds(),
+                ].map((x) => x.toString()).join('')];
+            case 'DT_YEAR':
+                return [now.getFullYear().toString()];
+            case 'DT_MONTH':
+                return [now.getMonth().toString()];
+            case 'DT_DAY':
+                return [now.getDay().toString()];
+            case 'DT_HOUR':
+                return [now.getHours().toString()];
+            case 'DT_MINUTE':
+                return [now.getMinutes().toString()];
+            case 'DT_SECOND':
+                return [now.getSeconds().toString()];
+            case 'DT_UTC_SIMPLE':
+                return [[
+                    now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDay(),
+                    now.getUTCHours(), now.getUTCMinutes(), now.getUTCSeconds(),
+                ].map((x) => x.toString()).join('')];
+            case 'DT_UTC_YEAR':
+                return [now.getUTCFullYear().toString()];
+            case 'DT_UTC_MONTH':
+                return [now.getUTCMonth().toString()];
+            case 'DT_UTC_DAY':
+                return [now.getUTCDay().toString()];
+            case 'DT_UTC_HOUR':
+                return [now.getUTCHours().toString()];
+            case 'DT_UTC_MINUTE':
+                return [now.getUTCMinutes().toString()];
+            case 'DT_UTC_SECOND':
+                return [now.getUTCSeconds().toString()];
+            case 'PICKFIELD':
+                return []; // TODO need modal
+            case 'PASSWORD_ENC':
+                return [cipher.login.password.encryptedString];
+            case 'HMACOTP':
+                return []; // TODO need HMACOTP generator
+            //  ----- Keys -----
+            case 'TAB':
+                return [RoboKeys.tab];
+            case 'ENTER':
+                return [RoboKeys.enter];
+            case 'UP':
+                return [RoboKeys.up];
+            case 'DOWN':
+                return [RoboKeys.down];
+            case 'LEFT':
+                return [RoboKeys.left];
+            case 'RIGHT':
+                return [RoboKeys.right];
+            case 'INSERT':
+            case 'INS':
+                return [RoboKeys.insert];
+            case 'DELETE':
+            case 'DEL':
+                return [RoboKeys.delete];
+            case 'HOME':
+                return [RoboKeys.home];
+            case 'END':
+                return [RoboKeys.end];
+            case 'PGUP':
+                return [RoboKeys.pageup];
+            case 'PGDN':
+                return [RoboKeys.pagedown];
+            case 'SPACE':
+                return [RoboKeys.space];
+            case 'BACKSPACE':
+            case 'BS':
+            case 'BKSP':
+                return [RoboKeys.backspace];
+            case 'BREAK':
+                return []; // TODO https://github.com/octalmage/robotjs/issues/490
+            case 'CAPSLOCK':
+                return []; // TODO https://github.com/octalmage/robotjs/issues/490
+            case 'ESC':
+                return [RoboKeys.escape];
+            case 'WIN':
+            case 'LWIN':
+                return [RoboKeys.command];
+            case 'RWIN':
+                return [RoboKeys.command];
+            case 'APPS':
+                return []; // TODO change to keycode after https://github.com/octalmage/robotjs/pull/357
+            case 'HELP':
+                return []; // TODO change to keycode after https://github.com/octalmage/robotjs/pull/357
+            case 'NUMLOCK':
+                return []; // TODO https://github.com/octalmage/robotjs/issues/490
+            case 'PRTSC':
+                return [RoboKeys.printscreen];
+            case 'SCROLLLOCK':
+                return []; // TODO https://github.com/octalmage/robotjs/issues/490
+            case 'ALT':
+                return [RoboKeys.alt];
+            case 'CTRL':
+                return [RoboKeys.control];
+            case 'SHIFT':
+                switch (param.toUpperCase()) {
+                    case 'RIGHT':
+                        return [RoboKeys.right_shift];
+                    case 'LEFT':
+                    default:
+                        return [RoboKeys.shift];
+                }
+            case 'F1':
+            case 'F2':
+            case 'F3':
+            case 'F4':
+            case 'F5':
+            case 'F6':
+            case 'F7':
+            case 'F8':
+            case 'F9':
+            case 'F10':
+            case 'F11':
+            case 'F12':
+                // @ts-ignore
+                return [RoboKeys[placeholder.toUpperCase()]];
+            case 'F13':
+            case 'F14':
+            case 'F15':
+            case 'F16':
+                return []; // Not supported
+            case '^':
+                return ['^'];
+            case '%':
+                return ['%'];
+            case '+':
+                return ['+'];
+            case '~':
+                return ['~'];
+            case 'ADD':
+                return ['+']; // TODO change to keycode after https://github.com/octalmage/robotjs/pull/357
+            case 'SUBTRACT':
+                return ['-']; // TODO change to keycode after https://github.com/octalmage/robotjs/pull/357
+            case 'MULTIPLY':
+                return ['*']; // TODO change to keycode after https://github.com/octalmage/robotjs/pull/357
+            case 'DIVIDE':
+                return ['/']; // TODO change to keycode after https://github.com/octalmage/robotjs/pull/357
+            case 'NUMPAD0':
+            case 'NUMPAD1':
+            case 'NUMPAD2':
+            case 'NUMPAD3':
+            case 'NUMPAD4':
+            case 'NUMPAD5':
+            case 'NUMPAD6':
+            case 'NUMPAD7':
+            case 'NUMPAD8':
+            case 'NUMPAD9':
+                // @ts-ignore
+                return [RoboKeys['numpad_' + placeholder.charAt(6)]];
+            // ---- Commands ----
+            case 'DELAY':
+                await new Promise((resolve) => setTimeout(resolve, parseInt(param, 10)));
+                return [];
+            case 'DELAY=':
+                const delay = param;
+                robot.setKeyboardDelay(parseInt(delay, 10));
+                return [];
+            case 'CLEARFIELD':
+                return [() => {
+                    // Select all and delete
+                    robot.keyTap('a', this.systemClipModifier );
+                    robot.keyTap('backspace');
+                    return Promise.resolve('');
+                }];
+            case 'APPACTIVATE':
+                return [() => {
+                    const window = windowManager.getWindows().find((w: Window) => w.getTitle().includes(param));
+                    if (window) { window.bringToTop(); }
+                    return Promise.resolve('');
+                }];
+            case 'BEEP':
+                const [freq, duration] = param.split(' ');
+                return [() => {
+                    beep(parseFloat(freq), parseInt(duration, 10));
+                    return Promise.resolve('');
+                }];
+            case 'VKEY':
+            case 'VKEY-NX':
+            case 'VKEY-EX':
+                return []; // TODO https://docs.microsoft.com/en-us/windows/desktop/inputdev/virtual-key-codes
+        }
+    }
+}


### PR DESCRIPTION
Some work still needs to be done to implement a popover model window to select a target when multiple matches occur. There are also other // TODO items in the code that are not critical.

I haven't looked at the changes needed to the server to store the new autotype rules.

Provides Keepass TCATO functionality, except rather than using a seeded rand, it compares to the median letter in the string. Anything less than that letter is typed using the clipboard. The consequence is weak, repetitive passwords stay weak.

Tries to be compatible with keepass placeholders.
{ALT}, {CTRL}, {SHIFT[ RIGHT|LEFT]} are added to allow tapping those buttons.

Some features waiting on https://github.com/octalmage/robotjs/pull/357 and https://github.com/octalmage/robotjs/issues/490