### PR TITLE
Only show carats for items with children

### DIFF
--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -73,7 +73,7 @@
                     <ng-template #recursiveCollections let-collections>
                         <li *ngFor="let c of collections" [ngClass]="{active: c.node.id === selectedCollectionId}">
                             <a href="#" appStopClick appBlurClick (click)="selectCollection(c.node)">
-                                <i class="fa-li fa" title="{{'toggleCollapse' | i18n}}" aria-hidden="true"
+                                <i *ngIf="c.children.length" class="fa-li fa" title="{{'toggleCollapse' | i18n}}" aria-hidden="true"
                                     [ngClass]="{'fa-caret-right': isCollapsed(c.node), 'fa-caret-down': !isCollapsed(c.node)}"
                                     (click)="collapse(c.node)" appStopProp></i>
                                 {{c.node.name}}

--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -50,7 +50,7 @@
                     <li *ngFor="let f of folders"
                         [ngClass]="{active: selectedFolder && f.node.id === selectedFolderId}">
                         <a href="#" appStopClick appBlurClick (click)="selectFolder(f.node)">
-                            <i class="fa-li fa" title="{{'toggleCollapse' | i18n}}" aria-hidden="true"
+                            <i *ngIf="f.children.length" class="fa-li fa" title="{{'toggleCollapse' | i18n}}" aria-hidden="true"
                                 [ngClass]="{'fa-caret-right': isCollapsed(f.node), 'fa-caret-down': !isCollapsed(f.node)}"
                                 (click)="collapse(f.node)" appStopProp></i>
                             {{f.node.name}}


### PR DESCRIPTION
This is a very small tweak, but it makes the app feel a lot higher quality.

ex:
![image](https://user-images.githubusercontent.com/778012/64141317-1980d300-cdf7-11e9-86a4-d7e52f84aefa.png)
