### PR TITLE
Make list item texts unselectable

### DIFF
--- a/src/scss/list.scss
+++ b/src/scss/list.scss
@@ -5,6 +5,7 @@
     padding: 3px 10px;
     text-decoration: none;
     position: relative;
+    user-select: none;
     z-index: 1;
 
     @include themify($themes) {


### PR DESCRIPTION
Currently, when you right click a list item while your cursor is on the item's name or username label, the icon and the text content of the item gets selected (select as in actual native text select). It's probably unintended, and probably not useful. The only use case I could think of is if the user wanted to copy the username from the item, but they can already do that through the context menu + in this case the item's name gets selected too.

Current behavior:
![Kapture 2019-10-01 at 20 17 58](https://user-images.githubusercontent.com/1512067/65989723-7f11bf00-e48a-11e9-86d9-1ddf618fbac0.gif)

This PR makes the text content of the list item unselectable.

After this quick tweak:
![Kapture 2019-10-01 at 20 19 51](https://user-images.githubusercontent.com/1512067/65989742-8638cd00-e48a-11e9-899a-5b2584c58bd1.gif)
