### PR TITLE
Allow special characters selection for pwd generation

### DIFF
--- a/src/app/vault/password-generator.component.html
+++ b/src/app/vault/password-generator.component.html
@@ -87,6 +87,13 @@
                                 <input id="special" type="checkbox" (change)="saveOptions()"
                                     [(ngModel)]="options.special">
                             </div>
+                            <div class="box-content-row checkbox-row" appBoxRow [hidden]="!options.special">
+                                <span *ngFor="let char of options.specialCharacters;">
+                                    <label for="specialCharactersSet">{{char}}</label>
+                                    <input id="specialCharactersSet" name="SpecialCharactersSet" type="checkbox" (change)="saveOptions()"
+                                    [(ngModel)]="options.specialCharactersValues[char]">
+                                </span>
+                            </div>
                         </div>
                     </div>
                     <div class="box" [hidden]="!showOptions">

--- a/src/scss/box.scss
+++ b/src/scss/box.scss
@@ -130,6 +130,24 @@
         }
     }
 
+    &.checkbox-row {
+        display: flex;
+        justify-content: flex-start;
+        flex-wrap: wrap;
+        align-content: space-between;
+
+        span {
+            display: inline-block;
+            width: 62px;
+            text-align: center;
+
+            label {
+                display: inline-block;
+                width: 12px;
+            }
+        }
+    }
+
     .text, .detail {
         display: block;
 


### PR DESCRIPTION
Hello! This is a small PR to allow selection of special characters during the password generation. A PR for jslib would be added separately (edit: https://github.com/bitwarden/jslib/pull/50).

The idea came after some resources did not allow using the password with special characters from bitwarden, though were requiring special characters in general (the set of allowed characters was limited). This led to changing pwd manually (to substitute some special characters) or just clicking "Regenerate" untill the right pwd would be created.

Below are the screenshot.
The first screen is with special characters off, untouched from the existing one:
<img width="295" alt="Screen Shot 2019-10-13 at 9 46 41 AM" src="https://user-images.githubusercontent.com/9346874/66716868-c3616100-eda0-11e9-9d2d-f29d72325273.png">
The second screen is  with an extra row of checkboxes, where characters for the password can be selected:
<img width="297" alt="Screen Shot 2019-10-13 at 9 46 21 AM" src="https://user-images.githubusercontent.com/9346874/66716873-c9efd880-eda0-11e9-99b7-b79171012bb7.png">

I'm trying to contribute for the first time to bitwarden repos, would you please let me know if anything else is required, `CONTRIBUTING.md` seems a bit short on the guidelines.
