### PR TITLE
Start drag only on row label

### DIFF
--- a/src/app/vault/view.component.html
+++ b/src/app/vault/view.component.html
@@ -12,8 +12,9 @@
                 <!-- Login -->
                 <div *ngIf="cipher.login">
                     <div class="box-content-row box-content-row-flex" *ngIf="cipher.login.username">
-                        <div class="row-main" draggable="true" (dragstart)="setTextDataOnDrag($event, cipher.login.username)">
-                            <span class="row-label">{{'username' | i18n}}</span>
+                        <div class="row-main">
+                            <span class="row-label draggable" draggable="true"
+                                (dragstart)="setTextDataOnDrag($event, cipher.login.username)">{{'username' | i18n}}</span>
                             {{cipher.login.username}}
                         </div>
                         <div class="action-buttons">
@@ -24,8 +25,9 @@
                         </div>
                     </div>
                     <div class="box-content-row box-content-row-flex" *ngIf="cipher.login.password">
-                        <div class="row-main" draggable="true" (dragstart)="setTextDataOnDrag($event, cipher.login.password)">
-                            <span class="row-label">{{'password' | i18n}}</span>
+                        <div class="row-main">
+                            <span class="row-label draggable" draggable="true"
+                                (dragstart)="setTextDataOnDrag($event, cipher.login.password)">{{'password' | i18n}}</span>
                             <div [hidden]="showPassword" class="monospaced">
                                 {{cipher.login.maskedPassword}}</div>
                             <div [hidden]="!showPassword" class="monospaced password-wrapper" appSelectCopy
@@ -52,10 +54,10 @@
                         </div>
                     </div>
                     <div class="box-content-row box-content-row-flex totp" [ngClass]="{'low': totpLow}"
-                        *ngIf="cipher.login.totp && totpCode"
-                        draggable="true" (dragstart)="setTextDataOnDrag($event, totpCode)">
+                        *ngIf="cipher.login.totp && totpCode">
                         <div class="row-main">
-                            <span class="row-label">{{'verificationCodeTotp' | i18n}}</span>
+                            <span class="row-label draggable" draggable="true"
+                                (dragstart)="setTextDataOnDrag($event, totpCode)">{{'verificationCodeTotp' | i18n}}</span>
                             <span class="totp-code">{{totpCodeFormatted}}</span>
                         </div>
                         <span class="totp-countdown">

--- a/src/scss/misc.scss
+++ b/src/scss/misc.scss
@@ -286,3 +286,7 @@ app-root > #loading {
 [hidden] {
     display: none !important;
 }
+
+.draggable {
+    cursor: move;
+}


### PR DESCRIPTION
As discussed in #333, this pull request changes the area where a drag can start to the label.
Also, the cursor is modified to be a "move" cursor, to indicate a draggable object.