### PR TITLE
Remove gconf as no longer needed by electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,8 +182,6 @@
     "deb": {
       "artifactName": "${productName}-${version}-${arch}.${ext}",
       "depends": [
-        "gconf2",
-        "gconf-service",
         "libnotify4",
         "libxtst6",
         "libnss3",


### PR DESCRIPTION
`gconf` has been deprecated and is [no longer required by electron](https://github.com/electron/electron/issues/2727).

Other electron applications such as Signal have [made the change already](https://github.com/signalapp/Signal-Desktop/issues/2344) and Bitwarden on the AUR has [dropped `gconf` from its dependencies](https://aur.archlinux.org/cgit/aur.git/log/?h=bitwarden-bin) today.