### PR TITLE
Enhanced title bar on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3758,6 +3758,11 @@
         "array-find-index": "^1.0.1"
       }
     },
+    "custom-electron-titlebar": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/custom-electron-titlebar/-/custom-electron-titlebar-3.2.1.tgz",
+      "integrity": "sha512-Bb+vgH0Vjz6pZfT6xDQ7K9C9EZBMkcC80CdiBneV42xMc2gEl9MAJ4VhTvAdSp3ryN/YgZgbLzqoyfJU6nNkRg=="
+    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",

--- a/package.json
+++ b/package.json
@@ -274,6 +274,7 @@
     "angulartics2": "6.3.0",
     "big-integer": "1.6.36",
     "core-js": "2.6.2",
+    "custom-electron-titlebar": "^3.2.1",
     "desktop-idle": "1.1.2",
     "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
     "electron-log": "2.2.17",

--- a/src/index.html
+++ b/src/index.html
@@ -2,9 +2,8 @@
 <html>
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline';
-        img-src 'self' data: *; child-src *; frame-src *; connect-src *;">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'nonce-5Uf8QQzQdAu2sRVG8A8O'; style-src 'self' 'unsafe-inline'; img-src 'self' data: *; child-src *; frame-src *; connect-src *;">
     <title>Bitwarden</title>
     <base href="">
 </head>
@@ -12,5 +11,34 @@
     <app-root>
         <div id="loading"><i class="fa fa-spinner fa-spin fa-3x" aria-hidden="true"></i></div>
     </app-root>
+
+    <script nonce="5Uf8QQzQdAu2sRVG8A8O">
+        const customElectronTitlebar = require('custom-electron-titlebar');
+
+        function getCurrentBodyColor() {
+            var rgb = window.getComputedStyle(document.body).backgroundColor.replace("rgb(", "").replace(")", "").split(", ");
+            return new customElectronTitlebar.Color(new customElectronTitlebar.RGBA(parseInt(rgb[0]), parseInt(rgb[1]), parseInt(rgb[2]), 255));
+        }
+
+        let bitwardenTitleBar = new customElectronTitlebar.Titlebar({
+            backgroundColor: getCurrentBodyColor(),
+            icon: "./images/icon.ico",
+            shadow: true,
+            title: "Bitwarden"
+        });
+
+        const observer = new MutationObserver((mutations) => {
+            document.documentElement.classList.forEach(function(className) {
+                if (className.startsWith("theme")) {
+                    bitwardenTitleBar.updateBackground(getCurrentBodyColor());
+                }
+            });
+        });
+        observer.observe(document.documentElement, {
+            attributes: true,
+            attributeOldValue: true,
+            attributeFilter: ['class']
+        });
+    </script>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,8 @@
     </app-root>
 
     <script nonce="5Uf8QQzQdAu2sRVG8A8O">
+        if (!(process.platform === 'win32')) return;
+
         const customElectronTitlebar = require('custom-electron-titlebar');
 
         function getCurrentBodyColor() {

--- a/src/index.html
+++ b/src/index.html
@@ -13,34 +13,34 @@
     </app-root>
 
     <script nonce="5Uf8QQzQdAu2sRVG8A8O">
-        if (!(process.platform === 'win32')) return;
+        if (process.platform === 'win32') {
+            const customElectronTitlebar = require('custom-electron-titlebar');
 
-        const customElectronTitlebar = require('custom-electron-titlebar');
+            function getCurrentBodyColor() {
+                var rgb = window.getComputedStyle(document.body).backgroundColor.replace("rgb(", "").replace(")", "").split(", ");
+                return new customElectronTitlebar.Color(new customElectronTitlebar.RGBA(parseInt(rgb[0]), parseInt(rgb[1]), parseInt(rgb[2]), 255));
+            }
 
-        function getCurrentBodyColor() {
-            var rgb = window.getComputedStyle(document.body).backgroundColor.replace("rgb(", "").replace(")", "").split(", ");
-            return new customElectronTitlebar.Color(new customElectronTitlebar.RGBA(parseInt(rgb[0]), parseInt(rgb[1]), parseInt(rgb[2]), 255));
-        }
-
-        let bitwardenTitleBar = new customElectronTitlebar.Titlebar({
-            backgroundColor: getCurrentBodyColor(),
-            icon: "./images/icon.ico",
-            shadow: true,
-            title: "Bitwarden"
-        });
-
-        const observer = new MutationObserver((mutations) => {
-            document.documentElement.classList.forEach(function(className) {
-                if (className.startsWith("theme")) {
-                    bitwardenTitleBar.updateBackground(getCurrentBodyColor());
-                }
+            let bitwardenTitleBar = new customElectronTitlebar.Titlebar({
+                backgroundColor: getCurrentBodyColor(),
+                icon: "./images/icon.ico",
+                shadow: true,
+                title: "Bitwarden"
             });
-        });
-        observer.observe(document.documentElement, {
-            attributes: true,
-            attributeOldValue: true,
-            attributeFilter: ['class']
-        });
+
+            const observer = new MutationObserver((mutations) => {
+                document.documentElement.classList.forEach(function(className) {
+                    if (className.startsWith("theme")) {
+                        bitwardenTitleBar.updateBackground(getCurrentBodyColor());
+                    }
+                });
+            });
+            observer.observe(document.documentElement, {
+                attributes: true,
+                attributeOldValue: true,
+                attributeFilter: ['class']
+            });
+        };
     </script>
 </body>
 </html>

--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -7,13 +7,15 @@
 }
 
 html, body {
-    height: 100%;
     font-family: $font-family-sans-serif;
     font-size: $font-size-base;
     line-height: $line-height-base;
+    height: 100%;
 }
 
 body {
+    height: calc(100%-15px);
+    margin: 15px 0 0 0;
     color: $text-color;
     background-color: $background-color-alt2;
 


### PR DESCRIPTION
Using [this library by AlexTorresSk](https://github.com/AlexTorresSk/custom-electron-titlebar) Bitwarden would be able to deliver a better title bar in dark/node theme. It is licensed under the MIT license and there suitable for Bitwarden.
To review it yourself you will have to modify the window creation function createWindow() and set the frame option to false when creating the window (this change could not be included in the PR).
The code is nowhere perfect but I would like to start a discussion on a possible implementation and enhancements.

The title bar under different themes lookes like this:
![lighttheme](https://user-images.githubusercontent.com/11543113/73215960-62924480-4155-11ea-8b31-1fc2d01fee5b.jpg)
![nord](https://user-images.githubusercontent.com/11543113/73215961-632adb00-4155-11ea-8b8e-75fc51ccd5ec.jpg)
![dark](https://user-images.githubusercontent.com/11543113/73215962-632adb00-4155-11ea-861f-1168aa908203.jpg)

Some improvements that still have to be implemented are:
- better MenuItem colors in light-theme and
- the use of a hashed inline-script instead of the nonce.

Any feedback is highly appreciated.