### PR TITLE
Add spacing to buttons in 'Login' / 'Lock' screens

### DIFF
--- a/src/app/accounts/lock.component.html
+++ b/src/app/accounts/lock.component.html
@@ -30,10 +30,10 @@
         </div>
         <div class="buttons">
             <button type="submit" class="btn primary block" appBlurClick>
-                <i class="fa fa-unlock-alt" aria-hidden="true"></i> <b>{{'unlock' | i18n}}</b>
+                <i class="fa fa-unlock-alt" aria-hidden="true"></i>&ensp;<b>{{'unlock' | i18n}}</b>
             </button>
-            <button type="button" class="btn block" appBlurClick (click)="logOut()">
-                {{'logOut' | i18n}}
+            <button type="button" class="btn danger block" appBlurClick (click)="logOut()">
+                <i class="fa fa-sign-out" aria-hidden="true"></i>&ensp;{{'logOut' | i18n}}
             </button>
         </div>
     </div>

--- a/src/app/accounts/login.component.html
+++ b/src/app/accounts/login.component.html
@@ -26,11 +26,11 @@
         </div>
         <div class="buttons">
             <button type="submit" class="btn primary block" [disabled]="form.loading" appBlurClick>
-                <b [hidden]="form.loading"><i class="fa fa-sign-in" aria-hidden="true"></i> {{'logIn' | i18n}}</b>
+                <b [hidden]="form.loading"><i class="fa fa-sign-in" aria-hidden="true"></i>&ensp;{{'logIn' | i18n}}</b>
                 <i class="fa fa-spinner fa-spin" [hidden]="!form.loading" aria-hidden="true"></i>
             </button>
             <a routerLink="/register" class="btn block">
-                <i class="fa fa-pencil-square-o" aria-hidden="true"></i> {{'createAccount' | i18n}}
+                <i class="fa fa-pencil-square-o" aria-hidden="true"></i>&ensp;{{'createAccount' | i18n}}
             </a>
         </div>
         <div class="sub-options">


### PR DESCRIPTION
1. On Login screen: added small space between icons and text to buttons:

<img width="314" alt="Bitwarden-with-space-buttons" src="https://user-images.githubusercontent.com/20100011/73552788-899c8f00-4451-11ea-936d-5c3dac04b5c0.png">, was: 
<img width="317" alt="Bitwarden-no-space-buttons" src="https://user-images.githubusercontent.com/20100011/73552846-a33dd680-4451-11ea-8e4f-7f995283beac.png">

2. On Lock screen: added icon to 'Logout' button, changed to red text and apped spacings to buttons:
![Screen Capture - Bitwarden Desktop](https://user-images.githubusercontent.com/20100011/73553091-07609a80-4452-11ea-82e3-468421579c3d.png)

Here are how buttons looks in different themes:
"Nord"
<img width="352" alt="Bitwarden-nord-theme" src="https://user-images.githubusercontent.com/20100011/73553266-53abda80-4452-11ea-85d5-4116b50267c0.png">
"Light"
<img width="369" alt="Bitwarden-light" src="https://user-images.githubusercontent.com/20100011/73553297-5e666f80-4452-11ea-84db-ff91f644c0c9.png">

