### PR TITLE
Enable Ownership/Collection assignment for cloned items

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -242,7 +242,7 @@
                         <i class="fa fa-chevron-right row-sub-icon" aria-hidden="true"></i>
                     </a>
                     <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
-                        (click)="editCollections()" *ngIf="editMode && cipher.organizationId" role="button">
+                        (click)="editCollections()" *ngIf="editMode && !cloneMode && cipher.organizationId" role="button">
                         <div class="row-main">{{'collections' | i18n}}</div>
                         <i class="fa fa-chevron-right row-sub-icon" aria-hidden="true"></i>
                     </a>
@@ -308,7 +308,7 @@
                     </div>
                 </div>
             </div>
-            <div class="box" *ngIf="!editMode && ownershipOptions && ownershipOptions.length > 1">
+            <div class="box" *ngIf="(!editMode || cloneMode) && ownershipOptions && ownershipOptions.length > 1">
                 <div class="box-header">
                     {{'ownership' | i18n}}
                 </div>
@@ -322,7 +322,7 @@
                     </div>
                 </div>
             </div>
-            <div class="box" *ngIf="!editMode && cipher.organizationId">
+            <div class="box" *ngIf="(!editMode || cloneMode) && cipher.organizationId">
                 <div class="box-header">
                     {{'collections' | i18n}}
                 </div>


### PR DESCRIPTION
> Cloned items should have the ability to assign ownership/collections

- **add-edit.component**: Adjusted field section visibility based on whether or not the item was being cloned.  Made sure editing assigned collections only appears in edit mode.

<img width="1904" alt="0-view-item" src="https://user-images.githubusercontent.com/26154748/73666116-e2de0b80-4667-11ea-968d-e63c88319e90.png">
<img width="154" alt="1-clone-item-button" src="https://user-images.githubusercontent.com/26154748/73666117-e376a200-4667-11ea-93aa-2cdc896f3261.png">
<img width="1174" alt="1 5-clone-context-menu" src="https://user-images.githubusercontent.com/26154748/73666118-e376a200-4667-11ea-86bb-28d0e7e484c0.png">
<img width="1904" alt="2-clone-item-fields" src="https://user-images.githubusercontent.com/26154748/73666119-e376a200-4667-11ea-9e0b-19e6b23654fa.png">
<img width="685" alt="2 5-clone-item-ownership-collection" src="https://user-images.githubusercontent.com/26154748/73666120-e376a200-4667-11ea-883d-5edc37e5504c.png">
<img width="1904" alt="3-clone-item-success" src="https://user-images.githubusercontent.com/26154748/73666121-e376a200-4667-11ea-81dc-7a7229334def.png">
<img width="1904" alt="4-restrict-org-clone" src="https://user-images.githubusercontent.com/26154748/73666123-e40f3880-4667-11ea-9314-d5388e5ce713.png">
