### PR TITLE
Added missing clone mode conditionals and fixed add/edit state bug

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -237,12 +237,13 @@
                         <input id="favorite" type="checkbox" name="Favorite" [(ngModel)]="cipher.favorite">
                     </div>
                     <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
-                        (click)="attachments()" *ngIf="editMode" role="button">
+                        (click)="attachments()" *ngIf="editMode && !cloneMode" role="button">
                         <div class="row-main">{{'attachments' | i18n}}</div>
                         <i class="fa fa-chevron-right row-sub-icon" aria-hidden="true"></i>
                     </a>
                     <a class="box-content-row box-content-row-flex text-default" href="#" appStopClick appBlurClick
-                        (click)="editCollections()" *ngIf="editMode && !cloneMode && cipher.organizationId" role="button">
+                        (click)="editCollections()" *ngIf="editMode && !cloneMode && cipher.organizationId"
+                        role="button">
                         <div class="row-main">{{'collections' | i18n}}</div>
                         <i class="fa fa-chevron-right row-sub-icon" aria-hidden="true"></i>
                     </a>

--- a/src/app/vault/add-edit.component.ts
+++ b/src/app/vault/add-edit.component.ts
@@ -36,6 +36,11 @@ export class AddEditComponent extends BaseAddEditComponent implements OnChanges 
 
     async ngOnChanges() {
         await super.init();
-        await super.load();
+        await this.load();
+    }
+
+    async load() {
+        this.cipher = null;
+        super.load();
     }
 }

--- a/src/app/vault/vault.component.ts
+++ b/src/app/vault/vault.component.ts
@@ -611,7 +611,7 @@ export class VaultComponent implements OnInit, OnDestroy {
     }
 
     private dirtyInput(): boolean {
-        return (this.action === 'add' || this.action === 'edit') &&
+        return (this.action === 'add' || this.action === 'edit' || this.action === 'clone') &&
             document.querySelectorAll('app-vault-add-edit .ng-dirty').length > 0;
     }
 


### PR DESCRIPTION
## Code Changes
- **add-edit.component.html**: Added missing `cloneMode` check for Attachments visibility
- **add-edit.component.ts**: Added `load` method overload to clear out the cipher so the user can't get the application in an unintended quasi-clone state
- **vault.component.ts**: Added action check for `clone` in order to properly allow prompting for unsaved changes