### PR TITLE
sweetalert2: remove superflous text argument.

### DIFF
--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -148,7 +148,6 @@ export class SettingsComponent implements OnInit {
             const submitted = await Swal.fire({
                 heightAuto: false,
                 buttonsStyling: false,
-                text: this.i18nService.t('setYourPinCode'),
                 html: div,
                 showCancelButton: true,
                 cancelButtonText: this.i18nService.t('cancel'),


### PR DESCRIPTION
This potentially causes problems when the library handling changes and it's not at all required as the text gets added as HTML element already.

I missed this. Sorry!