### PR TITLE
Enforce Password Generator Policy Options

### DIFF
--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -114,7 +114,7 @@ const lockService = new LockService(cipherService, folderService, collectionServ
 const syncService = new SyncService(userService, apiService, settingsService,
     folderService, cipherService, cryptoService, collectionService, storageService, messagingService, policyService,
     async (expired: boolean) => messagingService.send('logout', { expired: expired }));
-const passwordGenerationService = new PasswordGenerationService(cryptoService, storageService);
+const passwordGenerationService = new PasswordGenerationService(cryptoService, storageService, policyService);
 const totpService = new TotpService(storageService, cryptoFunctionService);
 const containerService = new ContainerService(cryptoService);
 const authService = new AuthService(cryptoService, apiService,

--- a/src/app/vault/password-generator.component.html
+++ b/src/app/vault/password-generator.component.html
@@ -70,22 +70,22 @@
                             <div class="box-content-row box-content-row-checkbox" appBoxRow>
                                 <label for="uppercase">A-Z</label>
                                 <input id="uppercase" type="checkbox" (change)="saveOptions()"
-                                    [(ngModel)]="options.uppercase">
+                                    [disabled]="enforcedPolicyOptions?.useUppercase" [(ngModel)]="options.uppercase">
                             </div>
                             <div class="box-content-row box-content-row-checkbox" appBoxRow>
                                 <label for="lowercase">a-z</label>
                                 <input id="lowercase" type="checkbox" (change)="saveOptions()"
-                                    [(ngModel)]="options.lowercase">
+                                    [disabled]="enforcedPolicyOptions?.useLowercase" [(ngModel)]="options.lowercase">
                             </div>
                             <div class="box-content-row box-content-row-checkbox" appBoxRow>
                                 <label for="numbers">0-9</label>
                                 <input id="numbers" type="checkbox" (change)="saveOptions()"
-                                    [(ngModel)]="options.number">
+                                    [disabled]="enforcedPolicyOptions?.useNumbers" [(ngModel)]="options.number">
                             </div>
                             <div class="box-content-row box-content-row-checkbox" appBoxRow>
                                 <label for="special">!@#$%^&*</label>
                                 <input id="special" type="checkbox" (change)="saveOptions()"
-                                    [(ngModel)]="options.special">
+                                    [disabled]="enforcedPolicyOptions?.useSpecial" [(ngModel)]="options.special">
                             </div>
                         </div>
                     </div>
@@ -93,12 +93,12 @@
                         <div class="box-content condensed">
                             <div class="box-content-row box-content-row-input" appBoxRow>
                                 <label for="min-number">{{'minNumbers' | i18n}}</label>
-                                <input id="min-number" type="number" min="0" max="9" (input)="saveOptions()"
+                                <input id="min-number" type="number" min="0" max="9" (blur)="saveOptions()"
                                     [(ngModel)]="options.minNumber">
                             </div>
                             <div class="box-content-row box-content-row-input" appBoxRow>
                                 <label for="min-special">{{'minSpecial' | i18n}}</label>
-                                <input id="min-special" type="number" min="0" max="9" (input)="saveOptions()"
+                                <input id="min-special" type="number" min="0" max="9" (blur)="saveOptions()"
                                     [(ngModel)]="options.minSpecial">
                             </div>
                             <div class="box-content-row box-content-row-checkbox" appBoxRow>


### PR DESCRIPTION
## Objective
Make sure the Password Generator enforces the specific rules set by an Organization for password generation. In the case of multiple Organizational rules, apply the stricter option.

## Code Changes
- **services.module.ts**: Added `policyService` into the `passwordGenerationService` constructor
- **password-generator.component.html**: Added `disabled` logic to all of the policy-tracked checkboxes. Adjusted the number count and special count input fields to `saveOptions` on `blur`. `input` changes weren't properly being tracked.

## Screenshots
<img width="302" alt="Screen Shot 2020-02-27 at 11 47 34 AM" src="https://user-images.githubusercontent.com/26154748/75471505-fa06d500-5957-11ea-902c-990e00df7f8e.png">
