### PR TITLE
Disable to select text in vault grouping

### DIFF
--- a/src/scss/vault.scss
+++ b/src/scss/vault.scss
@@ -27,6 +27,7 @@
         .inner-content {
             padding-bottom: 0;
             padding-right: 5px;
+            user-select: none;
 
             > ul, > div > ul {
                 margin: 0 0 15px 0;


### PR DESCRIPTION
I am using macOS version BW. I notice text selection of left pane is enabled.
This PR fixes it.

![image](https://user-images.githubusercontent.com/1213991/76518909-4fd49480-64a3-11ea-86a2-fa98dcf75bec.png)
