### PR TITLE
Enforce Passphrase Policy

### DIFF
--- a/src/app/vault/password-generator.component.html
+++ b/src/app/vault/password-generator.component.html
@@ -40,7 +40,7 @@
                     <div class="box-content condensed">
                         <div class="box-content-row box-content-row-input" appBoxRow>
                             <label for="num-words">{{'numWords' | i18n}}</label>
-                            <input id="num-words" type="number" min="3" max="20" (input)="saveOptions()"
+                            <input id="num-words" type="number" min="3" max="20" (blur)="saveOptions()"
                                 [(ngModel)]="options.numWords">
                         </div>
                         <div class="box-content-row box-content-row-input" appBoxRow>

--- a/src/app/vault/password-generator.component.html
+++ b/src/app/vault/password-generator.component.html
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-sm" role="document">
         <div class="modal-content">
             <div class="modal-body">
-                <app-callout type="info" *ngIf="policyInEffect">
+                <app-callout type="info" *ngIf="enforcedPolicyOptions?.inEffect()">
                     {{'passwordGeneratorPolicyInEffect' | i18n}}
                 </app-callout>
                 <div class="password-block">
@@ -51,12 +51,12 @@
                         <div class="box-content-row box-content-row-checkbox" appBoxRow>
                             <label for="capitalize">{{'capitalize' | i18n}}</label>
                             <input id="capitalize" type="checkbox" (change)="saveOptions()"
-                                [(ngModel)]="options.capitalize">
+                                [(ngModel)]="options.capitalize" [disabled]="enforcedPolicyOptions?.capitalize">
                         </div>
                         <div class="box-content-row box-content-row-checkbox" appBoxRow>
                             <label for="include-number">{{'includeNumber' | i18n}}</label>
                             <input id="include-number" type="checkbox" (change)="saveOptions()"
-                                [(ngModel)]="options.includeNumber">
+                                [(ngModel)]="options.includeNumber" [disabled]="enforcedPolicyOptions?.capitalize">
                         </div>
                     </div>
                 </div>

--- a/src/app/vault/password-generator.component.html
+++ b/src/app/vault/password-generator.component.html
@@ -56,7 +56,7 @@
                         <div class="box-content-row box-content-row-checkbox" appBoxRow>
                             <label for="include-number">{{'includeNumber' | i18n}}</label>
                             <input id="include-number" type="checkbox" (change)="saveOptions()"
-                                [(ngModel)]="options.includeNumber" [disabled]="enforcedPolicyOptions?.capitalize">
+                                [(ngModel)]="options.includeNumber" [disabled]="enforcedPolicyOptions?.includeNumber">
                         </div>
                     </div>
                 </div>

--- a/src/app/vault/password-generator.component.ts
+++ b/src/app/vault/password-generator.component.ts
@@ -1,4 +1,8 @@
-import { Component } from '@angular/core';
+import {
+    ChangeDetectorRef,
+    Component,
+    NgZone,
+} from '@angular/core';
 
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
@@ -14,7 +18,14 @@ import {
 })
 export class PasswordGeneratorComponent extends BasePasswordGeneratorComponent {
     constructor(passwordGenerationService: PasswordGenerationService, platformUtilsService: PlatformUtilsService,
-        i18nService: I18nService) {
+        i18nService: I18nService, private ngZone: NgZone, private changeDetectorRef: ChangeDetectorRef) {
         super(passwordGenerationService, platformUtilsService, i18nService, window);
+    }
+
+    async saveOptions() {
+        this.ngZone.run(async () => {
+            await super.saveOptions();
+            this.changeDetectorRef.detectChanges();
+        });
     }
 }

--- a/src/app/vault/password-generator.component.ts
+++ b/src/app/vault/password-generator.component.ts
@@ -1,8 +1,4 @@
-import {
-    ChangeDetectorRef,
-    Component,
-    NgZone,
-} from '@angular/core';
+import { Component } from '@angular/core';
 
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
@@ -18,14 +14,7 @@ import {
 })
 export class PasswordGeneratorComponent extends BasePasswordGeneratorComponent {
     constructor(passwordGenerationService: PasswordGenerationService, platformUtilsService: PlatformUtilsService,
-        i18nService: I18nService, private ngZone: NgZone, private changeDetectorRef: ChangeDetectorRef) {
+        i18nService: I18nService) {
         super(passwordGenerationService, platformUtilsService, i18nService, window);
-    }
-
-    async saveOptions() {
-        this.ngZone.run(async () => {
-            await super.saveOptions();
-            this.changeDetectorRef.detectChanges();
-        });
     }
 }


### PR DESCRIPTION
## Objective
> Add missing components for passphrase policy. Use existing data structures/patterns to implement a shared password generator (password/passphrase)

## Code Changes
- **jslib**: Update to 0a30c7e
- **password-generator.component.html**: Updated existing fields to respect potentially enforced options for passphrase generation. Update `numWords` input field to call `saveOptions()` using the `blur` event callback. This mimics the other platforms action.

## Screenshots
<img width="323" alt="0-pgp-enforced" src="https://user-images.githubusercontent.com/26154748/76572942-7980c200-6489-11ea-9bad-abfa3700a07d.png">
