### PR TITLE
Update jslib and enforce passphrase policy

### DIFF
--- a/src/app/vault/password-generator.component.html
+++ b/src/app/vault/password-generator.component.html
@@ -2,7 +2,7 @@
     <div class="modal-dialog modal-sm" role="document">
         <div class="modal-content">
             <div class="modal-body">
-                <app-callout type="info" *ngIf="policyInEffect">
+                <app-callout type="info" *ngIf="enforcedPolicyOptions?.inEffect()">
                     {{'passwordGeneratorPolicyInEffect' | i18n}}
                 </app-callout>
                 <div class="password-block">
@@ -40,7 +40,7 @@
                     <div class="box-content condensed">
                         <div class="box-content-row box-content-row-input" appBoxRow>
                             <label for="num-words">{{'numWords' | i18n}}</label>
-                            <input id="num-words" type="number" min="3" max="20" (input)="saveOptions()"
+                            <input id="num-words" type="number" min="3" max="20" (blur)="saveOptions()"
                                 [(ngModel)]="options.numWords">
                         </div>
                         <div class="box-content-row box-content-row-input" appBoxRow>
@@ -51,12 +51,12 @@
                         <div class="box-content-row box-content-row-checkbox" appBoxRow>
                             <label for="capitalize">{{'capitalize' | i18n}}</label>
                             <input id="capitalize" type="checkbox" (change)="saveOptions()"
-                                [(ngModel)]="options.capitalize">
+                                [(ngModel)]="options.capitalize" [disabled]="enforcedPolicyOptions?.capitalize">
                         </div>
                         <div class="box-content-row box-content-row-checkbox" appBoxRow>
                             <label for="include-number">{{'includeNumber' | i18n}}</label>
                             <input id="include-number" type="checkbox" (change)="saveOptions()"
-                                [(ngModel)]="options.includeNumber">
+                                [(ngModel)]="options.includeNumber" [disabled]="enforcedPolicyOptions?.includeNumber">
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Objective
> Add missing components for passphrase policy. Use existing data structures/patterns to implement a shared password generator (password/passphrase)

## Code Changes
- **jslib**: Update from b816ddd -> 0a30c7e
- **password-generator.component.html**: Updated existing fields to respect potentially enforced options for passphrase generation. Update `numWords` input field to call `saveOptions()` using the `blur` event callback. This mimics the other platforms action.

## Screenshots
<img width="323" alt="0-pgp-enforced" src="https://user-images.githubusercontent.com/26154748/76572942-7980c200-6489-11ea-9bad-abfa3700a07d.png">
