### PR TITLE
[Auto-Logout] Implement Vault Timeout Options

### DIFF
--- a/src/app/accounts/lock.component.ts
+++ b/src/app/accounts/lock.component.ts
@@ -4,12 +4,12 @@ import { Router } from '@angular/router';
 import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { EnvironmentService } from 'jslib/abstractions/environment.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
-import { LockService } from 'jslib/abstractions/lock.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { StateService } from 'jslib/abstractions/state.service';
 import { StorageService } from 'jslib/abstractions/storage.service';
 import { UserService } from 'jslib/abstractions/user.service';
+import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service';
 
 import { LockComponent as BaseLockComponent } from 'jslib/angular/components/lock.component';
 
@@ -21,9 +21,9 @@ export class LockComponent extends BaseLockComponent {
     constructor(router: Router, i18nService: I18nService,
         platformUtilsService: PlatformUtilsService, messagingService: MessagingService,
         userService: UserService, cryptoService: CryptoService,
-        storageService: StorageService, lockService: LockService,
+        storageService: StorageService, vaultTimeoutService: VaultTimeoutService,
         environmentService: EnvironmentService, stateService: StateService) {
         super(router, i18nService, platformUtilsService, messagingService, userService, cryptoService,
-            storageService, lockService, environmentService, stateService);
+            storageService, vaultTimeoutService, environmentService, stateService);
     }
 }

--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -8,12 +8,33 @@
                     </div>
                     <div class="box-content box-content-padded">
                         <div class="form-group">
-                            <label for="lockOption">{{'lockOptions' | i18n}}</label>
-                            <select id="lockOption" name="LockOption" [(ngModel)]="lockOption"
-                                (change)="saveLockOption()">
-                                <option *ngFor="let o of lockOptions" [ngValue]="o.value">{{o.name}}</option>
+                            <label for="vaultTimeouts">{{'vaultTimeout' | i18n}}</label>
+                            <select id="vaultTimeouts" name="VaultTimeouts" [(ngModel)]="vaultTimeout"
+                                (change)="saveVaultTimeoutOptions()">
+                                <option *ngFor="let o of vaultTimeouts" [ngValue]="o.value">{{o.name}}</option>
                             </select>
-                            <small class="help-block">{{'lockOptionsDesc' | i18n}}</small>
+                            <small class="help-block">{{'vaultTimeoutDesc' | i18n}}</small>
+                        </div>
+                        <div class="form-group">
+                            <label>{{'vaultTimeoutAction' | i18n}}</label>
+                            <div class="radio radio-mt-2">
+                                <label for="vaultTimeoutActionLock">
+                                    <input type="radio" name="VaultTimeoutAction" id="vaultTimeoutActionLock"
+                                        value="lock" [(ngModel)]="vaultTimeoutAction"
+                                        (change)="saveVaultTimeoutOptions()">
+                                    {{'lock' | i18n}}
+                                </label>
+                            </div>
+                            <small class="help-block">{{'vaultTimeoutActionLockDesc' | i18n}}</small>
+                            <div class="radio">
+                                <label for="vaultTimeoutActionLogOut">
+                                    <input type="radio" name="VaultTimeoutAction" id="vaultTimeoutActionLogOut"
+                                        value="logOut" [(ngModel)]="vaultTimeoutAction"
+                                        (change)="saveVaultTimeoutOptions()">
+                                    {{'logOut' | i18n}}
+                                </label>
+                            </div>
+                            <small class="help-block">{{'vaultTimeoutActionLogOutDesc' | i18n}}</small>
                         </div>
                         <div class="form-group">
                             <div class="checkbox">

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -11,12 +11,12 @@ import { DeviceType } from 'jslib/enums/deviceType';
 
 import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
-import { LockService } from 'jslib/abstractions/lock.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { StateService } from 'jslib/abstractions/state.service';
 import { StorageService } from 'jslib/abstractions/storage.service';
 import { UserService } from 'jslib/abstractions/user.service';
+import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service';
 
 import { ConstantsService } from 'jslib/services/constants.service';
 
@@ -29,7 +29,8 @@ import { Utils } from 'jslib/misc/utils';
     templateUrl: 'settings.component.html',
 })
 export class SettingsComponent implements OnInit {
-    lockOption: number = null;
+    vaultTimeout: number = null;
+    vaultTimeoutAction: string;
     pin: boolean = null;
     disableFavicons: boolean = false;
     enableMinToTray: boolean = false;
@@ -38,7 +39,7 @@ export class SettingsComponent implements OnInit {
     showMinToTray: boolean = false;
     startToTray: boolean = false;
     locale: string;
-    lockOptions: any[];
+    vaultTimeouts: any[];
     localeOptions: any[];
     theme: string;
     themeOptions: any[];
@@ -49,14 +50,14 @@ export class SettingsComponent implements OnInit {
 
     constructor(private analytics: Angulartics2, private toasterService: ToasterService,
         private i18nService: I18nService, private platformUtilsService: PlatformUtilsService,
-        private storageService: StorageService, private lockService: LockService,
+        private storageService: StorageService, private vaultTimeoutService: VaultTimeoutService,
         private stateService: StateService, private messagingService: MessagingService,
         private userService: UserService, private cryptoService: CryptoService) {
         const trayKey = this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop ?
             'enableMenuBar' : 'enableTray';
         this.enableTrayText = this.i18nService.t(trayKey);
         this.enableTrayDescText = this.i18nService.t(trayKey + 'Desc');
-        this.lockOptions = [
+        this.vaultTimeouts = [
             // { name: i18nService.t('immediately'), value: 0 },
             { name: i18nService.t('oneMinute'), value: 1 },
             { name: i18nService.t('fiveMinutes'), value: 5 },
@@ -69,10 +70,10 @@ export class SettingsComponent implements OnInit {
         ];
 
         if (this.platformUtilsService.getDevice() !== DeviceType.LinuxDesktop) {
-            this.lockOptions.push({ name: i18nService.t('onLocked'), value: -2 });
+            this.vaultTimeouts.push({ name: i18nService.t('onLocked'), value: -2 });
         }
 
-        this.lockOptions = this.lockOptions.concat([
+        this.vaultTimeouts = this.vaultTimeouts.concat([
             { name: i18nService.t('onRestart'), value: -1 },
             { name: i18nService.t('never'), value: null },
         ]);
@@ -109,8 +110,9 @@ export class SettingsComponent implements OnInit {
 
     async ngOnInit() {
         this.showMinToTray = this.platformUtilsService.getDevice() === DeviceType.WindowsDesktop;
-        this.lockOption = await this.storageService.get<number>(ConstantsService.lockOptionKey);
-        const pinSet = await this.lockService.isPinLockSet();
+        this.vaultTimeout = await this.storageService.get<number>(ConstantsService.vaultTimeoutKey);
+        this.vaultTimeoutAction = await this.storageService.get<string>(ConstantsService.vaultTimeoutActionKey);
+        const pinSet = await this.vaultTimeoutService.isPinLockSet();
         this.pin = pinSet[0] || pinSet[1];
         this.disableFavicons = await this.storageService.get<boolean>(ConstantsService.disableFaviconKey);
         this.enableMinToTray = await this.storageService.get<boolean>(ElectronConstants.enableMinimizeToTrayKey);
@@ -122,8 +124,9 @@ export class SettingsComponent implements OnInit {
         this.clearClipboard = await this.storageService.get<number>(ConstantsService.clearClipboardKey);
     }
 
-    async saveLockOption() {
-        await this.lockService.setLockOption(this.lockOption != null ? this.lockOption : null);
+    async saveVaultTimeoutOptions() {
+        await this.vaultTimeoutService.setVaultTimeoutOptions(this.vaultTimeout != null ? this.vaultTimeout : null,
+            this.vaultTimeoutAction);
     }
 
     async updatePin() {
@@ -171,7 +174,7 @@ export class SettingsComponent implements OnInit {
                 if (masterPassOnRestart) {
                     const encPin = await this.cryptoService.encrypt(pin);
                     await this.storageService.save(ConstantsService.protectedPin, encPin.encryptedString);
-                    this.lockService.pinProtectedKey = pinProtectedKey;
+                    this.vaultTimeoutService.pinProtectedKey = pinProtectedKey;
                 } else {
                     await this.storageService.save(ConstantsService.pinProtectedKey, pinProtectedKey.encryptedString);
                 }
@@ -181,7 +184,7 @@ export class SettingsComponent implements OnInit {
         }
         if (!this.pin) {
             await this.cryptoService.clearPinProtectedKey();
-            await this.lockService.clear();
+            await this.vaultTimeoutService.clear();
         }
     }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,11 +36,11 @@ import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { EventService } from 'jslib/abstractions/event.service';
 import { FolderService } from 'jslib/abstractions/folder.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
-import { LockService } from 'jslib/abstractions/lock.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { NotificationsService } from 'jslib/abstractions/notifications.service';
 import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
 import { SearchService } from 'jslib/abstractions/search.service';
 import { SettingsService } from 'jslib/abstractions/settings.service';
 import { StateService } from 'jslib/abstractions/state.service';
@@ -49,6 +49,7 @@ import { SyncService } from 'jslib/abstractions/sync.service';
 import { SystemService } from 'jslib/abstractions/system.service';
 import { TokenService } from 'jslib/abstractions/token.service';
 import { UserService } from 'jslib/abstractions/user.service';
+import { VaultTimeoutService } from 'jslib/abstractions/vaultTimeout.service';
 
 import { ConstantsService } from 'jslib/services/constants.service';
 
@@ -90,12 +91,13 @@ export class AppComponent implements OnInit {
         private authService: AuthService, private router: Router, private analytics: Angulartics2,
         private toasterService: ToasterService, private i18nService: I18nService,
         private sanitizer: DomSanitizer, private ngZone: NgZone,
-        private lockService: LockService, private storageService: StorageService,
+        private vaultTimeoutService: VaultTimeoutService, private storageService: StorageService,
         private cryptoService: CryptoService, private componentFactoryResolver: ComponentFactoryResolver,
         private messagingService: MessagingService, private collectionService: CollectionService,
         private searchService: SearchService, private notificationsService: NotificationsService,
         private platformUtilsService: PlatformUtilsService, private systemService: SystemService,
-        private stateService: StateService, private eventService: EventService) { }
+        private stateService: StateService, private eventService: EventService,
+        private policyService: PolicyService) { }
 
     ngOnInit() {
         this.ngZone.runOutsideAngular(() => {
@@ -136,7 +138,7 @@ export class AppComponent implements OnInit {
                         this.logOut(!!message.expired);
                         break;
                     case 'lockVault':
-                        await this.lockService.lock(true);
+                        await this.vaultTimeoutService.lock(true);
                         break;
                     case 'locked':
                         if (this.modal != null) {
@@ -205,7 +207,7 @@ export class AppComponent implements OnInit {
     private async updateAppMenu() {
         this.messagingService.send('updateAppMenu', {
             isAuthenticated: await this.userService.isAuthenticated(),
-            isLocked: await this.lockService.isLocked(),
+            isLocked: await this.vaultTimeoutService.isLocked(),
         });
     }
 
@@ -224,8 +226,9 @@ export class AppComponent implements OnInit {
             this.folderService.clear(userId),
             this.collectionService.clear(userId),
             this.passwordGenerationService.clear(),
-            this.lockService.clear(),
+            this.vaultTimeoutService.clear(),
             this.stateService.purge(),
+            this.policyService.clear(userId),
         ]);
 
         this.searchService.clearIndex();

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -769,11 +769,11 @@
   "twoStepLogin": {
     "message": "Two-step Login"
   },
-  "lockOptions": {
-    "message": "Lock Options"
+  "vaultTimeout": {
+    "message": "Vault Timeout"
   },
-  "lockOptionsDesc": {
-    "message": "Choose when your vault locks. A locked vault requires that you re-enter your master password to access it again."
+  "vaultTimeoutDesc": {
+    "message": "Choose when your vault will timeout and perform the selected action."
   },
   "immediately": {
     "message": "Immediately"
@@ -1279,5 +1279,17 @@
   },
   "passwordGeneratorPolicyInEffect": {
     "message": "One or more organization policies are affecting your generator settings."
+  },
+  "vaultTimeoutAction": {
+    "message": "Vault Timeout Action"
+  },
+  "vaultTimeoutActionLockDesc": {
+    "message": "A locked vault requires that you re-enter your master password to access it again."
+  },
+  "vaultTimeoutActionLogOutDesc": {
+    "message": "A logged out vault requires that you re-authenticate to access it again."
+  },
+  "lock": {
+    "message": "Lock"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,8 +82,9 @@ export class Main {
         this.i18nService = new I18nService('en', './locales/');
 
         const storageDefaults: any = {};
-        // Default lock options to "on restart".
-        storageDefaults[ConstantsService.lockOptionKey] = -1;
+        // Default vault timeout to "on restart", and action to "lock"
+        storageDefaults[ConstantsService.vaultTimeoutKey] = -1;
+        storageDefaults[ConstantsService.vaultTimeoutActionKey] = 'lock';
         this.storageService = new ElectronStorageService(app.getPath('userData'), storageDefaults);
 
         this.windowMain = new WindowMain(this.storageService, true);

--- a/src/main/powerMonitor.main.ts
+++ b/src/main/powerMonitor.main.ts
@@ -21,9 +21,10 @@ export class PowerMonitorMain {
         if (!isSnapStore()) {
             // System sleep
             powerMonitor.on('suspend', async () => {
-                const lockOption = await this.getLockOption();
-                if (lockOption === -3) {
-                    this.main.messagingService.send('lockVault');
+                const options = await this.getVaultTimeoutOptions();
+                if (options[0] === -3) {
+                    options[1] === 'lock' ? this.main.messagingService.send('lockVault') :
+                        this.main.messagingService.send('logout', { expired: false });
                 }
             });
         }
@@ -31,9 +32,10 @@ export class PowerMonitorMain {
         if (process.platform !== 'linux') {
             // System locked
             powerMonitor.on('lock-screen', async () => {
-                const lockOption = await this.getLockOption();
-                if (lockOption === -2) {
-                    this.main.messagingService.send('lockVault');
+                const options = await this.getVaultTimeoutOptions();
+                if (options[0] === -2) {
+                    options[1] === 'lock' ? this.main.messagingService.send('lockVault') :
+                        this.main.messagingService.send('logout', { expired: false });
                 }
             });
         }
@@ -47,9 +49,10 @@ export class PowerMonitorMain {
                     return;
                 }
 
-                const lockOption = await this.getLockOption();
-                if (lockOption === -4) {
-                    this.main.messagingService.send('lockVault');
+                const options = await this.getVaultTimeoutOptions();
+                if (options[0] === -4) {
+                    options[1] === 'lock' ? this.main.messagingService.send('lockVault') :
+                        this.main.messagingService.send('logout', { expired: false });
                 }
             }
 
@@ -57,7 +60,9 @@ export class PowerMonitorMain {
         }, IdleCheckInterval);
     }
 
-    private getLockOption(): Promise<number> {
-        return this.main.storageService.get<number>(ConstantsService.lockOptionKey);
+    private async getVaultTimeoutOptions(): Promise<[number, string]> {
+        const timeout = await this.main.storageService.get<number>(ConstantsService.vaultTimeoutKey);
+        const action = await this.main.storageService.get<string>(ConstantsService.vaultTimeoutActionKey);
+        return [timeout, action];
     }
 }

--- a/src/scss/misc.scss
+++ b/src/scss/misc.scss
@@ -253,6 +253,27 @@ form, .form {
         }
     }
 
+    .radio {
+        position: relative;
+        display: block;
+        padding-left: 18px;
+        margin-top: 4px;
+
+        &.radio-mt-2 {
+            margin-top: 2px;
+        }
+
+        label {
+            margin-bottom: 0;
+        }
+
+        input[type="radio"] {
+            position: absolute;
+            margin-top: 4px;
+            margin-left: -18px;
+        }
+    }
+
     .help-block {
         margin-top: 3px;
         display: block;


### PR DESCRIPTION
## Objective
> Update the desktop application to use the updated `VaultTimeoutService` to allow for logging out on an interval timeout.  Allow users to choose what action takes place when the timer expires (Lock vs Log out)

## Code Changes
- **jslib**: Updated from `31a2574` to `28e3fff`
- **lock.component.ts**: Updated import. Updated constructor. 
- **settings.component.html**: Updated name dependencies. Added `vaultTimeoutAction` options.
- **settings.component.ts**: Updated import. Updated variable names to reflect `vaultTimeout..` pattern. Updated constructor. Updated necessary calls to the new `vaultTimeoutService`. Saving new selected action.
- **app.component.ts**: Updated import and added `PolicyService`.  The `PolicyService` call to `clear` was missing from (only) the desktop client log out cleanup. Updated necessary calls to the new `vaultTimeoutService`.
- **services.module.ts**: Updated imports. Added callback to log out and updated variables to use `vaultTimeoutService`.
- **messages.json**: Added necessary strings
- **main.ts**: Updated defaults for vault timeout settings
- **powerMonitor.main.ts**: Updated methods to lock/log based on saved action. Added tuple return type for evaluation.
- **misc.scss**: Added radio button styles.

## Screenshots
<img width="511" alt="Screen Shot 2020-03-31 at 2 00 14 PM" src="https://user-images.githubusercontent.com/26154748/78076349-daeecf00-736b-11ea-9747-736e93f4bde4.png">
