### PR TITLE
[Soft Delete] - Added trash to desktop app

### DIFF
--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -39,7 +39,7 @@
     </ng-container>
 </div>
 <div class="footer">
-    <button appBlurClick (click)="(deleted ? false : addCipher())" (contextmenu)="addCipherOptions()" 
+    <button appBlurClick (click)="addCipher()" (contextmenu)="addCipherOptions()" 
         class="block primary" appA11yTitle="{{'addItem' | i18n}}" [disabled]="deleted">
         <i class="fa fa-plus fa-lg" aria-hidden="true"></i>
     </button>

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -39,8 +39,8 @@
     </ng-container>
 </div>
 <div class="footer">
-    <button appBlurClick (click)="addCipher()" (contextmenu)="addCipherOptions()" class="block primary"
-        appA11yTitle="{{'addItem' | i18n}}">
+    <button appBlurClick (click)="(deleted ? false : addCipher())" (contextmenu)="addCipherOptions()" 
+        class="block primary" appA11yTitle="{{'addItem' | i18n}}" [disabled]="deleted">
         <i class="fa fa-plus fa-lg" aria-hidden="true"></i>
     </button>
 </div>

--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -13,6 +13,11 @@
                     <i class="fa fa-fw fa-star" aria-hidden="true"></i>&nbsp;{{'favorites' | i18n}}
                 </a>
             </li>
+            <li [ngClass]="{active: selectedTrash}">
+                <a href="#" appStopClick appBlurClick (click)="selectTrash()">
+                    <i class="fa fa-fw fa-trash-o" aria-hidden="true"></i>&nbsp;{{'trash' | i18n}}
+                </a>
+            </li>
         </ul>
         <h2>{{'types' | i18n}}</h2>
         <ul>

--- a/src/app/vault/vault.component.html
+++ b/src/app/vault/vault.component.html
@@ -2,7 +2,7 @@
     <app-vault-groupings id="groupings" (onAllClicked)="clearGroupingFilters()" (onFavoritesClicked)="filterFavorites()"
         (onCipherTypeClicked)="filterCipherType($event)" (onFolderClicked)="filterFolder($event.id)"
         (onAddFolder)="addFolder()" (onEditFolder)="editFolder($event.id)"
-        (onCollectionClicked)="filterCollection($event.id)">
+        (onCollectionClicked)="filterCollection($event.id)" (onTrashClicked)="filterDeleted()">
     </app-vault-groupings>
     <app-vault-ciphers id="items" [activeCipherId]="cipherId" (onCipherClicked)="viewCipher($event)"
         (onCipherRightClicked)="viewCipherMenu($event)" (onAddCipher)="addCipher($event)"
@@ -10,7 +10,8 @@
     </app-vault-ciphers>
     <app-vault-view id="details" *ngIf="cipherId && action === 'view'" [cipherId]="cipherId"
         (onCloneCipher)="cloneCipher($event)" (onEditCipher)="editCipher($event)" 
-        (onViewCipherPasswordHistory)="viewCipherPasswordHistory($event)">
+        (onViewCipherPasswordHistory)="viewCipherPasswordHistory($event)" (onRestoredCipher)="restoredCipher($event)"
+        (onDeletedCipher)="deletedCipher($event)">
     </app-vault-view>
     <app-vault-add-edit id="details" *ngIf="action === 'add' || action === 'edit' || action === 'clone'"
         [cloneMode]="action === 'clone'"

--- a/src/app/vault/view.component.html
+++ b/src/app/vault/view.component.html
@@ -273,10 +273,21 @@
     </div>
 </div>
 <div class="footer">
-    <button appBlurClick class="primary" (click)="edit()" appA11yTitle="{{'edit' | i18n}}">
+    <button appBlurClick class="primary" (click)="edit()" appA11yTitle="{{'edit' | i18n}}" *ngIf="!cipher.isDeleted">
         <i class="fa fa-pencil fa-fw fa-lg" aria-hidden="true"></i>
     </button>
-    <button appBlurClick class="primary" *ngIf="!cipher?.organizationId" (click)="clone()" appA11yTitle="{{'clone' | i18n}}">
+    <button appBlurClick class="primary" (click)="restore()" appA11yTitle="{{'restore' | i18n}}" 
+        *ngIf="cipher.isDeleted">
+        <i class="fa fa-undo fa-fw fa-lg" aria-hidden="true"></i>
+    </button>
+    <button appBlurClick class="primary" *ngIf="!cipher?.organizationId && !cipher.isDeleted" (click)="clone()" 
+        appA11yTitle="{{'clone' | i18n}}">
         <i class="fa fa-clone fa-fw fa-lg" aria-hidden="true"></i>
     </button>
+    <div class="right">
+        <button appBlurClick type="button" (click)="delete()" class="danger"
+            appA11yTitle="{{(cipher.isDeleted ? 'permanentlyDelete' : 'delete') | i18n}}">
+            <i class="fa fa-trash-o fa-lg fa-fw" aria-hidden="true"></i>
+        </button>
+    </div>
 </div>

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1292,5 +1292,33 @@
   "lock": {
     "message": "Lock",
     "description": "Verb form: to make secure or inaccesible by"
+  },
+  "trash": {
+    "message": "Trash",
+    "description": "Noun: a special folder to hold deleted items"
+  },
+  "searchTrash": {
+    "message": "Search trash"
+  },
+  "permanentlyDeleteItem": {
+    "message": "Permanently Delete Item"
+  },
+  "permanentlyDeleteItemConfirmation": {
+    "message": "Are you sure you want to permanently delete this item?"
+  },
+  "permanentlyDeletedItem": {
+    "message": "Permanently Deleted item"
+  },
+  "restoreItem": {
+    "message": "Restore Item"
+  },
+  "restoreItemConfirmation": {
+    "message": "Are you sure you want to restore this item?"
+  },
+  "restoredItem": {
+    "message": "Restored Item"
+  },
+  "permanentlyDelete": {
+    "message": "Permanently Delete"
   }
 }


### PR DESCRIPTION
## Objective
This adds the Trash bin and soft-delete/restore functionality to the Desktop client.

## Changes
- **ciphers.component.html**: Prevent adding a new cipher to the Trash directly
- **groupings.component.html**: Added Trash "folder" to top-level groupings navigation
- **vault.component.html**: Added vault orchestration event hooks/handlers for deleted and restored items
- **vault.component.ts**: Added deleted item view (trash) context tracking and state management. Also managed context menus for items in trash vs. not deleted
- **view.component.html**: Added delete and restore buttons

## Screenshots
Added the Delete button to the View, and the Trash "folder" to the groupings navigation along with contextual changes for deleted items.
![image](https://user-images.githubusercontent.com/3904944/79152043-84d15100-7d99-11ea-9c78-a50274846fed.png)
