### PR TITLE
[Auto Logout] Added warning dialog for log out action

### DIFF
--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -128,6 +128,16 @@ export class SettingsComponent implements OnInit {
     }
 
     async saveVaultTimeoutOptions() {
+        if (this.vaultTimeoutAction === 'logOut') {
+            const confirmed = await this.platformUtilsService.showDialog(
+                this.i18nService.t('vaultTimeoutLogOutConfirmation'),
+                this.i18nService.t('vaultTimeoutLogOutConfirmationTitle'),
+                this.i18nService.t('yes'), this.i18nService.t('cancel'), 'warning');
+            if (!confirmed) {
+                this.vaultTimeoutAction = 'lock';
+                return;
+            }
+        }
         await this.vaultTimeoutService.setVaultTimeoutOptions(this.vaultTimeout != null ? this.vaultTimeout : null,
             this.vaultTimeoutAction);
     }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1298,5 +1298,11 @@
   "lock": {
     "message": "Lock",
     "description": "Verb form: to make secure or inaccesible by"
+  },
+  "vaultTimeoutLogOutConfirmation": {
+    "message": "Logging out will remove all access to your vault and requires online authentication after the timeout period. Are you sure you want to use this setting?"
+  },
+  "vaultTimeoutLogOutConfirmationTitle": {
+    "message": "Timeout Action Confirmation"
   }
 }


### PR DESCRIPTION
## Objective
> Users selecting the `Log Out` timeout action need to be made more aware of the necessary requirements for accessing their vault next time.

## Code Changes
- **settings.component.ts**: Added warning dialog if selected vault action is `logOut`. 
- **messages.json**: Added title and body for warning dialog

## Screenshots
<img width="682" alt="1-logout-warning" src="https://user-images.githubusercontent.com/26154748/80261279-9d6e2080-864f-11ea-9ce2-3d8ab1e4fceb.png">

