### PR TITLE
Added GenericName for app on Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,12 @@
         "rpm",
         "AppImage",
         "snap"
-      ]
+      ],
+      "desktop": {
+        "Name": "Bitwarden",
+        "Type": "Application",
+        "GenericName": "Password Manager"
+      }
     },
     "dmg": {
       "icon": "dmg.icns",


### PR DESCRIPTION
Added "GenericName" field for Bitwarden's [desktop option for Linux](https://www.electron.build/configuration/linux), so that its icon displays a useful subtitle in menus and taskbars (demonstrated in screenshots below).

Since the [convention](https://developer.gnome.org/desktop-entry-spec/#recognized-keys) is a short descriptive label of what the app is, and other password managers like KeePassXC and Keeper use "Password Manager", I also used "Password Manager".

**Pic 1.** Example of what other apps look like In the KDE taskbar:
![Pic1](https://user-images.githubusercontent.com/29703429/80304956-0cd54300-87fd-11ea-82d1-c01aad8c761a.png)

**Pic 2.** What Bitwarden looks like before change:
![Pic2](https://user-images.githubusercontent.com/29703429/80305001-5a51b000-87fd-11ea-9d24-76d31ecfa776.png)

**Pic 3.** What Bitwarden looks like after change:
![Pic3](https://user-images.githubusercontent.com/29703429/80305008-65a4db80-87fd-11ea-9a15-02ec5d1acb5e.png)

**Pic 4.** Bitwarden in KDE Application Launcher before change:
![Pic4](https://user-images.githubusercontent.com/29703429/80305011-6b022600-87fd-11ea-8c7a-df82af902876.png)

**Pic 5.** Bitwarden in KDE Application Launcher after change:
![Pic5](https://user-images.githubusercontent.com/29703429/80305020-78b7ab80-87fd-11ea-9603-b0feac3c0394.png)

This brings its appearance/behaviour in line with other apps on Linux.

There shouldn't be any other unexpected changes to the app on Linux, since the generated Desktop Entry file is the same except the new "GenericName".

**Pic 6.** Desktop entry file before change:
![Pic6](https://user-images.githubusercontent.com/29703429/80305023-7fdeb980-87fd-11ea-9ae0-4b0375451c3c.png)

**Pic 7.** Desktop entry file after change:
![Pic7](https://user-images.githubusercontent.com/29703429/80305027-853c0400-87fd-11ea-917e-5c8a15699ee3.png)

*(built & tested on Kubuntu 18.04)*