### PR TITLE
Add support for U2F devices for Snap Package

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
       "confinement": "strict",
       "plugs": [
         "default",
-        "password-manager-service"
+        "password-manager-service",
+        "u2f-devices"
       ],
       "stagePackages": [
         "default"


### PR DESCRIPTION
Hello,

Bitwarden Desktop installed using snap package in Ubuntu does not support U2F devices.

This patch should allow the built snap package to interact with U2F devices.

--edit--

Didn't realise that U2F is not supported on the main application, not the build method..