### PR TITLE
[Bug] Update lock to be default timeout action

### DIFF
--- a/src/main/powerMonitor.main.ts
+++ b/src/main/powerMonitor.main.ts
@@ -23,8 +23,8 @@ export class PowerMonitorMain {
             powerMonitor.on('suspend', async () => {
                 const options = await this.getVaultTimeoutOptions();
                 if (options[0] === -3) {
-                    options[1] === 'lock' ? this.main.messagingService.send('lockVault') :
-                        this.main.messagingService.send('logout', { expired: false });
+                    options[1] === 'logOut' ? this.main.messagingService.send('logout', { expired: false }) :
+                        this.main.messagingService.send('lockVault');
                 }
             });
         }
@@ -34,8 +34,8 @@ export class PowerMonitorMain {
             powerMonitor.on('lock-screen', async () => {
                 const options = await this.getVaultTimeoutOptions();
                 if (options[0] === -2) {
-                    options[1] === 'lock' ? this.main.messagingService.send('lockVault') :
-                        this.main.messagingService.send('logout', { expired: false });
+                    options[1] === 'logOut' ? this.main.messagingService.send('logout', { expired: false }) :
+                        this.main.messagingService.send('lockVault');
                 }
             });
         }
@@ -51,8 +51,8 @@ export class PowerMonitorMain {
 
                 const options = await this.getVaultTimeoutOptions();
                 if (options[0] === -4) {
-                    options[1] === 'lock' ? this.main.messagingService.send('lockVault') :
-                        this.main.messagingService.send('logout', { expired: false });
+                    options[1] === 'logOut' ? this.main.messagingService.send('logout', { expired: false }) :
+                        this.main.messagingService.send('lockVault');
                 }
             }
 


### PR DESCRIPTION
## Objective
> Update any scenarios where a lock vs logout action are compared and make sure `lock` is the default state in case the action is `null`

## Code Changes
- **jslib**: Updated from 2de8c5e to 212a2e3
- **powerMonitor.main.ts**: Changed conditionals to use `lock` as the default option instead of `logOut`
