### PR TITLE
[SSO] Add set password placeholder

### DIFF
--- a/src/app/accounts/set-password.component.html
+++ b/src/app/accounts/set-password.component.html
@@ -2,104 +2,111 @@
     <div class="content">
         <img class="logo-image" alt="Bitwarden">
         <p class="lead">{{'setMasterPassword' | i18n}}</p>
-        <div class="box">
-            <app-callout type="tip">{{'ssoCompleteRegistration' | i18n}}</app-callout>
-            <app-callout type="info" *ngIf="enforcedPolicyOptions">
-                {{'masterPasswordPolicyInEffect' | i18n}}
-                <ul>
-                    <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
-                        {{'policyInEffectMinComplexity' | i18n : getPasswordScoreAlertDisplay()}}
-                    </li>
-                    <li *ngIf="enforcedPolicyOptions?.minLength > 0">
-                        {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}
-                    </li>
-                    <li *ngIf="enforcedPolicyOptions?.requireUpper">{{'policyInEffectUppercase' | i18n}}</li>
-                    <li *ngIf="enforcedPolicyOptions?.requireLower">{{'policyInEffectLowercase' | i18n}}</li>
-                    <li *ngIf="enforcedPolicyOptions?.requireNumbers">{{'policyInEffectNumbers' | i18n}}</li>
-                    <li *ngIf="enforcedPolicyOptions?.requireSpecial">{{'policyInEffectSpecial' | i18n : '!@#$%^&*'}}
-                    </li>
-                </ul>
-            </app-callout>
+        <div class="box text-center" *ngIf="syncLoading">
+            <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
+            {{'loading' | i18n}}
         </div>
-        <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate autocomplete="off">
+        <div *ngIf="!syncLoading">
             <div class="box">
-                <div class="box-content">
-                    <div class="box-content-row" appBoxRow>
-                        <div class="box-content-row-flex">
-                            <div class="row-main">
-                                <label for="masterPassword">{{'masterPass' | i18n}}
-                                    <strong class="sub-label text-{{masterPasswordScoreColor}}"
-                                        *ngIf="masterPasswordScoreText">
-                                        {{masterPasswordScoreText}}
-                                    </strong>
-                                </label>
-                                <input id="masterPassword" type="{{showPassword ? 'text' : 'password'}}"
-                                    name="MasterPassword" class="monospaced" [(ngModel)]="masterPassword" required
-                                    (input)="updatePasswordStrength()" appInputVerbatim>
+                <app-callout type="tip">{{'ssoCompleteRegistration' | i18n}}</app-callout>
+                <app-callout type="info" *ngIf="enforcedPolicyOptions">
+                    {{'masterPasswordPolicyInEffect' | i18n}}
+                    <ul>
+                        <li *ngIf="enforcedPolicyOptions?.minComplexity > 0">
+                            {{'policyInEffectMinComplexity' | i18n : getPasswordScoreAlertDisplay()}}
+                        </li>
+                        <li *ngIf="enforcedPolicyOptions?.minLength > 0">
+                            {{'policyInEffectMinLength' | i18n : enforcedPolicyOptions?.minLength.toString()}}
+                        </li>
+                        <li *ngIf="enforcedPolicyOptions?.requireUpper">{{'policyInEffectUppercase' | i18n}}</li>
+                        <li *ngIf="enforcedPolicyOptions?.requireLower">{{'policyInEffectLowercase' | i18n}}</li>
+                        <li *ngIf="enforcedPolicyOptions?.requireNumbers">{{'policyInEffectNumbers' | i18n}}</li>
+                        <li *ngIf="enforcedPolicyOptions?.requireSpecial">
+                            {{'policyInEffectSpecial' | i18n : '!@#$%^&*'}}
+                        </li>
+                    </ul>
+                </app-callout>
+            </div>
+            <form #form (ngSubmit)="submit()" [appApiAction]="formPromise" ngNativeValidate autocomplete="off">
+                <div class="box">
+                    <div class="box-content">
+                        <div class="box-content-row" appBoxRow>
+                            <div class="box-content-row-flex">
+                                <div class="row-main">
+                                    <label for="masterPassword">{{'masterPass' | i18n}}
+                                        <strong class="sub-label text-{{masterPasswordScoreColor}}"
+                                            *ngIf="masterPasswordScoreText">
+                                            {{masterPasswordScoreText}}
+                                        </strong>
+                                    </label>
+                                    <input id="masterPassword" type="{{showPassword ? 'text' : 'password'}}"
+                                        name="MasterPassword" class="monospaced" [(ngModel)]="masterPassword" required
+                                        (input)="updatePasswordStrength()" appInputVerbatim>
+                                </div>
+                                <div class="action-buttons">
+                                    <a class="row-btn" href="#" appStopClick appBlurClick role="button"
+                                        appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword(false)">
+                                        <i class="fa fa-lg" aria-hidden="true"
+                                            [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
+                                    </a>
+                                </div>
                             </div>
-                            <div class="action-buttons">
-                                <a class="row-btn" href="#" appStopClick appBlurClick role="button"
-                                    appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword(false)">
-                                    <i class="fa fa-lg" aria-hidden="true"
-                                        [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
-                                </a>
+                            <div class="progress">
+                                <div class="progress-bar bg-{{masterPasswordScoreColor}}" role="progressbar"
+                                    aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"
+                                    [ngStyle]="{width: (masterPasswordScoreWidth + '%')}"
+                                    attr.aria-valuenow="{{masterPasswordScoreWidth}}">
+                                </div>
                             </div>
                         </div>
-                        <div class="progress">
-                            <div class="progress-bar bg-{{masterPasswordScoreColor}}" role="progressbar"
-                                aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"
-                                [ngStyle]="{width: (masterPasswordScoreWidth + '%')}"
-                                attr.aria-valuenow="{{masterPasswordScoreWidth}}">
+                    </div>
+                    <div class="box-footer">
+                        {{'masterPassDesc' | i18n}}
+                    </div>
+                </div>
+                <div class="box">
+                    <div class="box-content">
+                        <div class="box-content-row" appBoxRow>
+                            <div class="box-content-row-flex">
+                                <div class="row-main">
+                                    <label for="masterPasswordRetype">{{'reTypeMasterPass' | i18n}}</label>
+                                    <input id="masterPasswordRetype" type="password" name="MasterPasswordRetype"
+                                        class="monospaced" [(ngModel)]="masterPasswordRetype" required appInputVerbatim
+                                        autocomplete="new-password">
+                                </div>
+                                <div class="action-buttons">
+                                    <a class="row-btn" href="#" appStopClick appBlurClick role="button"
+                                        appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword(true)">
+                                        <i class="fa fa-lg" aria-hidden="true"
+                                            [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
+                                    </a>
+                                </div>
                             </div>
                         </div>
                     </div>
                 </div>
-                <div class="box-footer">
-                    {{'masterPassDesc' | i18n}}
-                </div>
-            </div>
-            <div class="box">
-                <div class="box-content">
-                    <div class="box-content-row" appBoxRow>
-                        <div class="box-content-row-flex">
-                            <div class="row-main">
-                                <label for="masterPasswordRetype">{{'reTypeMasterPass' | i18n}}</label>
-                                <input id="masterPasswordRetype" type="password" name="MasterPasswordRetype"
-                                    class="monospaced" [(ngModel)]="masterPasswordRetype" required appInputVerbatim
-                                    autocomplete="new-password">
-                            </div>
-                            <div class="action-buttons">
-                                <a class="row-btn" href="#" appStopClick appBlurClick role="button"
-                                    appA11yTitle="{{'toggleVisibility' | i18n}}" (click)="togglePassword(true)">
-                                    <i class="fa fa-lg" aria-hidden="true"
-                                        [ngClass]="{'fa-eye': !showPassword, 'fa-eye-slash': showPassword}"></i>
-                                </a>
-                            </div>
+                <div class="box last">
+                    <div class="box-content">
+                        <div class="box-content-row" appBoxRow>
+                            <label for="hint">{{'masterPassHint' | i18n}}</label>
+                            <input id="hint" type="text" name="Hint" [(ngModel)]="hint">
                         </div>
                     </div>
-                </div>
-            </div>
-            <div class="box last">
-                <div class="box-content">
-                    <div class="box-content-row" appBoxRow>
-                        <label for="hint">{{'masterPassHint' | i18n}}</label>
-                        <input id="hint" type="text" name="Hint" [(ngModel)]="hint">
+                    <div class="box-footer">
+                        {{'masterPassHintDesc' | i18n}}
                     </div>
                 </div>
-                <div class="box-footer">
-                    {{'masterPassHintDesc' | i18n}}
+                <div class="buttons">
+                    <button type="submit" class="btn primary block" [disabled]="form.loading">
+                        <i *ngIf="form.loading" class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}"
+                            aria-hidden="true"></i>
+                        <span>{{'submit' | i18n}}</span>
+                    </button>
+                    <button class="btn block" (click)="logOut()">
+                        <span>{{'logOut' | i18n}}</span>
+                    </button>
                 </div>
-            </div>
-            <div class="buttons">
-                <button type="submit" class="btn primary block" [disabled]="form.loading">
-                    <i *ngIf="form.loading" class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}"
-                        aria-hidden="true"></i>
-                    <span>{{'submit' | i18n}}</span>
-                </button>
-                <button class="btn block" (click)="logOut()">
-                    <span>{{'logOut' | i18n}}</span>
-                </button>
-            </div>
-        </form>
+            </form>
+        </div>
     </div>
 </form>

--- a/src/app/accounts/set-password.component.ts
+++ b/src/app/accounts/set-password.component.ts
@@ -9,6 +9,7 @@ import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PasswordGenerationService } from 'jslib/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { PolicyService } from 'jslib/abstractions/policy.service';
+import { SyncService } from 'jslib/abstractions/sync.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
 import {
@@ -23,9 +24,10 @@ export class SetPasswordComponent extends BaseSetPasswordComponent {
     constructor(apiService: ApiService, i18nService: I18nService,
         cryptoService: CryptoService, messagingService: MessagingService,
         userService: UserService, passwordGenerationService: PasswordGenerationService,
-        platformUtilsService: PlatformUtilsService, policyService: PolicyService, router: Router) {
+        platformUtilsService: PlatformUtilsService, policyService: PolicyService, router: Router,
+        syncService: SyncService) {
         super(i18nService, cryptoService, messagingService, userService, passwordGenerationService,
-            platformUtilsService, policyService, router, apiService);
+            platformUtilsService, policyService, router, apiService, syncService);
     }
 
     get masterPasswordScoreWidth() {


### PR DESCRIPTION
## Objective
> For potentially long-lasting sync operations on the initialization of the set-password flow: add a loading placeholder.

## Code Changes
- **jslib**: Update from 6ab444a to 700e945
- **set-password.component.html**: Added UI for loading placeholder
- **set-password.component.ts**: Adjusted import and updated ctor call with `syncService`

## Screenshots
<img width="428" alt="Screen Shot 2020-08-28 at 9 46 04 AM" src="https://user-images.githubusercontent.com/26154748/91581689-6321d200-e914-11ea-86f1-c6a985a1f226.png">
