### PR TITLE
Added protocol for AppImage build

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,15 @@
       "publish": [
         "github"
       ]
-    }
+    },
+    "protocols": [
+      {
+        "name": "Bitwarden",
+        "schemes": [
+          "bitwarden"
+        ]
+      }
+    ]
   },
   "devDependencies": {
     "@angular/compiler-cli": "^9.1.12",


### PR DESCRIPTION
## Overview
Turns out that `app. setAsDefaultProtocolClient()` won't work for Linux, that instead you need electron-builder to put the custom protocol mimeType into the `.desktop` file for the AppImage. Added the necessary protocol configuration to the package.json file to accomplish this. Tested on Fedora 32.

see: https://github.com/electron-userland/electron-builder/issues/4035 for background as well.

_SHOULD_ resolve and close #551 