### PR TITLE
added a draggable class for electron

### DIFF
--- a/src/scss/base.scss
+++ b/src/scss/base.scss
@@ -16,7 +16,7 @@ html, body {
 body {
     color: $text-color;
     background-color: $background-color-alt2;
-
+    -webkit-app-region: drag;
     @include themify($themes) {
         color: themed('textColor');
         background-color: themed('backgroundColorAlt2');


### PR DESCRIPTION
Closes https://github.com/bitwarden/desktop/issues/528

### Issue 😧
Click and drag for MacOs is impossible from the vault screen except from a small area above the search box, even when there is ample other empty space around (like if no login is selected)

### Solution 💰
Add a css selector to signify the app as draggable

### Risk ⚠️
The [electron docs](https://www.electronjs.org/docs/api/frameless-window#draggable-region) on draggable-region mentions that if a you apply it to the entire document, as I have here, you need to specify certain fields like buttons as being not-draggable. I did not do anything for this, as all buttons, links, and text inputs in the app seemed to be working fine without it, but I would consider this a risk.