### PR TITLE
[SSO] New user provision flow jslib update (f0dc38b -> d84d6da)

### DIFF
--- a/src/app/accounts/set-password.component.ts
+++ b/src/app/accounts/set-password.component.ts
@@ -1,6 +1,9 @@
 import { Component } from '@angular/core';
 
-import { Router } from '@angular/router';
+import {
+    ActivatedRoute,
+    Router,
+} from '@angular/router';
 
 import { ApiService } from 'jslib/abstractions/api.service';
 import { CryptoService } from 'jslib/abstractions/crypto.service';
@@ -25,9 +28,9 @@ export class SetPasswordComponent extends BaseSetPasswordComponent {
         cryptoService: CryptoService, messagingService: MessagingService,
         userService: UserService, passwordGenerationService: PasswordGenerationService,
         platformUtilsService: PlatformUtilsService, policyService: PolicyService, router: Router,
-        syncService: SyncService) {
+        syncService: SyncService, route: ActivatedRoute) {
         super(i18nService, cryptoService, messagingService, userService, passwordGenerationService,
-            platformUtilsService, policyService, router, apiService, syncService);
+            platformUtilsService, policyService, router, apiService, syncService, route);
     }
 
     get masterPasswordScoreWidth() {

--- a/src/app/accounts/two-factor.component.ts
+++ b/src/app/accounts/two-factor.component.ts
@@ -5,7 +5,10 @@ import {
     ViewContainerRef,
 } from '@angular/core';
 
-import { Router } from '@angular/router';
+import {
+    ActivatedRoute,
+    Router,
+} from '@angular/router';
 
 import { TwoFactorOptionsComponent } from './two-factor-options.component';
 
@@ -36,9 +39,9 @@ export class TwoFactorComponent extends BaseTwoFactorComponent {
         i18nService: I18nService, apiService: ApiService,
         platformUtilsService: PlatformUtilsService, syncService: SyncService,
         environmentService: EnvironmentService, private componentFactoryResolver: ComponentFactoryResolver,
-        stateService: StateService, storageService: StorageService) {
+        stateService: StateService, storageService: StorageService, route: ActivatedRoute) {
         super(authService, router, i18nService, apiService, platformUtilsService, window, environmentService,
-            stateService, storageService);
+            stateService, storageService, route);
         super.onSuccessfulLogin = () => {
             return syncService.fullSync(true);
         };


### PR DESCRIPTION
## Objective 
> Currently, when a new bitwarden/org user is created, they are given a status of accepted. This can create issues for organizations trying to confirm the same user (which can't happen until they've set their master password). To alleviate the issue, change new user's orgUser status to invited until after they've set a master password.

## Code Changes
- **jslib**: Update from f0dc38b to d84d6da
- **Components**: Update imports/constructors to pass in the active route