### PR TITLE
[Policy] Personal Ownership

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -311,7 +311,7 @@
                     </div>
                 </div>
             </div>
-            <div class="box" *ngIf="(!editMode || cloneMode) && ownershipOptions && ownershipOptions.length > 1">
+            <div class="box" *ngIf="allowOwnershipOptions()">
                 <div class="box-header">
                     {{'ownership' | i18n}}
                 </div>

--- a/src/app/vault/add-edit.component.ts
+++ b/src/app/vault/add-edit.component.ts
@@ -13,6 +13,7 @@ import { FolderService } from 'jslib/abstractions/folder.service';
 import { I18nService } from 'jslib/abstractions/i18n.service';
 import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
+import { PolicyService } from 'jslib/abstractions/policy.service';
 import { StateService } from 'jslib/abstractions/state.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
@@ -32,9 +33,10 @@ export class AddEditComponent extends BaseAddEditComponent implements OnChanges,
         auditService: AuditService, stateService: StateService,
         userService: UserService, collectionService: CollectionService,
         messagingService: MessagingService, eventService: EventService,
-        private broadcasterService: BroadcasterService, private ngZone: NgZone) {
+        policyService: PolicyService, private broadcasterService: BroadcasterService,
+        private ngZone: NgZone) {
         super(cipherService, folderService, i18nService, platformUtilsService, auditService, stateService,
-            userService, collectionService, messagingService, eventService);
+            userService, collectionService, messagingService, eventService, policyService);
     }
 
     async ngOnInit() {
@@ -76,5 +78,10 @@ export class AddEditComponent extends BaseAddEditComponent implements OnChanges,
                 field.showValue = false;
             });
         }
+    }
+
+    allowOwnershipOptions(): boolean {
+        return (!this.editMode || this.cloneMode) && this.ownershipOptions
+            && (this.ownershipOptions.length > 1 || !this.allowPersonal);
     }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1438,7 +1438,6 @@
   "acceptPoliciesError": {
     "message": "Terms of Service and Privacy Policy have not been acknowledged."
   },
-<<<<<<< HEAD
   "enableBrowserIntegration": {
     "message": "Enable browser integration"
   },
@@ -1453,9 +1452,8 @@
   },
   "verifyBrowserDescription": {
     "message": "Please ensure the shown fingerprint is identical to the fingerprint showed in the browser extension."
-=======
+  },
   "personalOwnershipSubmitError": {
     "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership Option to an organization and choose from available Collections."
->>>>>>> Initial commit of personal ownership
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1438,6 +1438,7 @@
   "acceptPoliciesError": {
     "message": "Terms of Service and Privacy Policy have not been acknowledged."
   },
+<<<<<<< HEAD
   "enableBrowserIntegration": {
     "message": "Enable browser integration"
   },
@@ -1452,5 +1453,9 @@
   },
   "verifyBrowserDescription": {
     "message": "Please ensure the shown fingerprint is identical to the fingerprint showed in the browser extension."
+=======
+  "personalOwnershipSubmitError": {
+    "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership Option to an organization and choose from available Collections."
+>>>>>>> Initial commit of personal ownership
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1457,6 +1457,6 @@
     "message": "Please ensure the shown fingerprint is identical to the fingerprint showed in the browser extension."
   },
   "personalOwnershipSubmitError": {
-    "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership Option to an organization and choose from available Collections."
+    "message": "Due to an Enterprise Policy, you are restricted from saving items to your personal vault. Change the Ownership option to an organization and choose from available Collections."
   }
 }


### PR DESCRIPTION
## Objective
> Allow organizations to restrict user's from saving added/cloned items to their personal vaults. Remove the personal ownership option when this policy is enabled and the user is not an Admin/Owner of the organization.

## Code Changes
- **add-edit.component.html**: Adjusted visibility conditional to use `allowOwnershipOptions`
- **add-edit.component.ts**: Added `PolicyService` to the constructor and super call.  Added `allowOwnershipOptions` method that mimics the other clients.
- **messages.json**: Added error message for client-side validation
- **jslib**: Updated from dcbd09e to 72bf18f

## Screenshots
- Incoming...