### PR TITLE
Desktop fit & finish bugfixes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -93,7 +93,7 @@ export class Main {
         this.storageService = new ElectronStorageService(app.getPath('userData'), storageDefaults);
 
         this.windowMain = new WindowMain(this.storageService, true, undefined, undefined,
-            (arg) => this.processDeepLink(arg));
+            (arg) => this.processDeepLink(arg), (win) => this.trayMain.setupWindowListeners(win));
         this.messagingMain = new MessagingMain(this, this.storageService);
         this.updaterMain = new UpdaterMain(this.i18nService, this.windowMain, 'desktop', () => {
             this.menuMain.updateMenuItem.enabled = false;


### PR DESCRIPTION
Resolves the bugs found during testing for #601.

* Fix dock icon not working when minimized to menu bar.
* Fix window listeners not working after closing the main window

Since the main window on Mac can be closed without quitting the application, this caused the Tray window listeners to disappear and not work until the application was restarted. Resolved by setting up a callback in createWindow.

Depends on https://github.com/bitwarden/jslib/pull/223.