### PR TITLE
Fix autostart in snap

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
       "artifactName": "${productName}-${version}-${arch}.${ext}"
     },
     "snap": {
+      "autoStart": true,
       "confinement": "strict",
       "plugs": [
         "default",

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -53,6 +53,7 @@ export class SettingsComponent implements OnInit {
     alwaysShowDock: boolean;
     showAlwaysShowDock: boolean = false;
     openAtLogin: boolean;
+    requireEnableTray: boolean = false;
 
     enableTrayText: string;
     enableTrayDescText: string;
@@ -69,6 +70,9 @@ export class SettingsComponent implements OnInit {
         private stateService: StateService, private messagingService: MessagingService,
         private userService: UserService, private cryptoService: CryptoService) {
         const isMac = this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop;
+
+        // Workaround to avoid ghosting trays https://github.com/electron/electron/issues/17622
+        this.requireEnableTray = this.platformUtilsService.getDevice() === DeviceType.LinuxDesktop;
 
         const trayKey = isMac ? 'enableMenuBar' : 'enableTray';
         this.enableTrayText = this.i18nService.t(trayKey);
@@ -269,17 +273,40 @@ export class SettingsComponent implements OnInit {
     }
 
     async saveCloseToTray() {
+        if (this.requireEnableTray) {
+            this.enableTray = true;
+        }
+
         await this.storageService.save(ElectronConstants.enableCloseToTrayKey, this.enableCloseToTray);
         this.callAnalytics('CloseToTray', this.enableCloseToTray);
     }
 
     async saveTray() {
+        if (this.requireEnableTray && !this.enableTray && (this.startToTray || this.enableCloseToTray)) {
+            const confirm = await this.platformUtilsService.showDialog(
+                this.i18nService.t('confirmTrayDesc'), this.i18nService.t('confirmTrayTitle'),
+                this.i18nService.t('yes'), this.i18nService.t('no'), 'warning');
+
+            if (confirm) {
+                this.startToTray = false;
+                this.enableCloseToTray = false;
+            } else {
+                this.enableTray = true;
+            }
+
+            return;
+        }
+
         await this.storageService.save(ElectronConstants.enableTrayKey, this.enableTray);
         this.callAnalytics('Tray', this.enableTray);
         this.messagingService.send(this.enableTray ? 'showTray' : 'removeTray');
     }
 
     async saveStartToTray() {
+        if (this.requireEnableTray) {
+            this.enableTray = true;
+        }
+
         await this.storageService.save(ElectronConstants.enableStartToTrayKey, this.startToTray);
         this.callAnalytics('StartToTray', this.startToTray);
     }

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -275,6 +275,7 @@ export class SettingsComponent implements OnInit {
     async saveCloseToTray() {
         if (this.requireEnableTray) {
             this.enableTray = true;
+            await this.storageService.save(ElectronConstants.enableTrayKey, this.enableTray);
         }
 
         await this.storageService.save(ElectronConstants.enableCloseToTrayKey, this.enableCloseToTray);
@@ -289,7 +290,9 @@ export class SettingsComponent implements OnInit {
 
             if (confirm) {
                 this.startToTray = false;
+                await this.storageService.save(ElectronConstants.enableStartToTrayKey, this.startToTray);
                 this.enableCloseToTray = false;
+                await this.storageService.save(ElectronConstants.enableCloseToTrayKey, this.enableCloseToTray);
             } else {
                 this.enableTray = true;
             }
@@ -305,6 +308,7 @@ export class SettingsComponent implements OnInit {
     async saveStartToTray() {
         if (this.requireEnableTray) {
             this.enableTray = true;
+            await this.storageService.save(ElectronConstants.enableTrayKey, this.enableTray);
         }
 
         await this.storageService.save(ElectronConstants.enableStartToTrayKey, this.startToTray);

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -900,6 +900,12 @@
   "alwaysShowDockDesc": {
     "message": "Show the Bitwarden icon in the Dock even when minimized to the menu bar."
   },
+  "confirmTrayTitle": {
+    "message": "Confirm disable tray"
+  },
+  "confirmTrayDesc": {
+    "message": "Disabling this setting will also disable all other tray related settings."
+  },
   "language": {
     "message": "Language"
   },

--- a/src/main/messaging.main.ts
+++ b/src/main/messaging.main.ts
@@ -102,13 +102,13 @@ export class MessagingMain {
     private addOpenAtLogin() {
         if (process.platform === 'linux') {
             const data = `[Desktop Entry]
-            Type=Application
-            Version=${app.getVersion()}
-            Name=Bitwarden
-            Comment=Bitwarden startup script
-            Exec=${app.getPath('exe')}
-            StartupNotify=false
-            Terminal=false`;
+Type=Application
+Version=${app.getVersion()}
+Name=Bitwarden
+Comment=Bitwarden startup script
+Exec=${app.getPath('exe')}
+StartupNotify=false
+Terminal=false`;
 
             const dir = path.dirname(this.linuxStartupFile());
             if (!fs.existsSync(dir)) {


### PR DESCRIPTION
This resolves the autostart not working correctly in snap packages on linux.

Also ensures that "Enable tray icon" is enabled when using other tray related settings on linux.
![image](https://user-images.githubusercontent.com/137855/102264890-8fd71500-3f16-11eb-8e37-88ed1684b3e6.png)