### PR TITLE
Force update of tray menu if on linux

### DIFF
--- a/src/main/messaging.main.ts
+++ b/src/main/messaging.main.ts
@@ -97,6 +97,7 @@ export class MessagingMain {
         if (lockNowTrayMenuItem != null) {
             lockNowTrayMenuItem.enabled = isAuthenticated && !isLocked;
         }
+        this.main.trayMain.updateContextMenu();
     }
 
     private addOpenAtLogin() {


### PR DESCRIPTION
# Overview

Closes #493 and relies upon bitwarden/jslib#233. This update method will do nothing unless on Linux, in which case the context menu object will be updated.

> Note: I have been unable to build this on Windows. I believe this is just my setup, but we need to test Tray behavior prior to merging

# Files Changed

* **messaging.main.ts**: Call jslib update tray context menu method.

# Draft reason

waiting on jslib PR bitwarden/jslib#233