### PR TITLE
Updated to show icon vs. caret for non-nested item

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1971,6 +1971,11 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -3705,7 +3710,7 @@
       "dev": true
     },
     "duo_web_sdk": {
-      "version": "git+https://github.com/duosecurity/duo_web_sdk.git#410a9186cc34663c4913b17d6528067cd3331f1d",
+      "version": "git+https://github.com/duosecurity/duo_web_sdk.git#4c5df7a4001b8b03e2d7130d9096b697c4032e77",
       "from": "git+https://github.com/duosecurity/duo_web_sdk.git"
     },
     "duplexer3": {

--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -50,15 +50,16 @@
                     <i class="fa fa-plus fa-fw" aria-hidden="true"></i>
                 </button>
             </div>
-            <ul class="fa-ul">
+            <ul>
                 <ng-template #recursiveFolders let-folders>
                     <li *ngFor="let f of folders"
                         [ngClass]="{active: selectedFolder && f.node.id === selectedFolderId}">
                         <a href="#" appStopClick appBlurClick (click)="selectFolder(f.node)">
-                            <i *ngIf="f.children.length" class="fa-li fa" title="{{'toggleCollapse' | i18n}}" aria-hidden="true"
+                            <i *ngIf="f.children.length" class="fa-fw fa" title="{{'toggleCollapse' | i18n}}" aria-hidden="true"
                                 [ngClass]="{'fa-caret-right': isCollapsed(f.node), 'fa-caret-down': !isCollapsed(f.node)}"
                                 (click)="collapse(f.node)" appStopProp></i>
-                            {{f.node.name}}
+                            <i *ngIf="f.children.length === 0" class="fa-fw fa fa-folder-o" aria-hidden="true"></i>
+                            &nbsp;{{f.node.name}}
                             <span appStopProp appStopClick (click)="editFolder(f.node)" role="button"
                                 appA11yTitle="{{'editFolder' | i18n}}" *ngIf="f.node.id">
                                 <i class="fa fa-pencil fa-fw" aria-hidden="true"></i>
@@ -74,14 +75,15 @@
             </ul>
             <div *ngIf="collections && collections.length">
                 <h2>{{'collections' | i18n}}</h2>
-                <ul class="fa-ul">
+                <ul>
                     <ng-template #recursiveCollections let-collections>
                         <li *ngFor="let c of collections" [ngClass]="{active: c.node.id === selectedCollectionId}">
                             <a href="#" appStopClick appBlurClick (click)="selectCollection(c.node)">
-                                <i *ngIf="c.children.length" class="fa-li fa" title="{{'toggleCollapse' | i18n}}" aria-hidden="true"
+                                <i *ngIf="c.children.length" class="fa-fw fa" title="{{'toggleCollapse' | i18n}}" aria-hidden="true"
                                     [ngClass]="{'fa-caret-right': isCollapsed(c.node), 'fa-caret-down': !isCollapsed(c.node)}"
                                     (click)="collapse(c.node)" appStopProp></i>
-                                {{c.node.name}}
+                                <i *ngIf="c.children.length === 0" class="fa-fw fa fa-cube" aria-hidden="true"></i>
+                                &nbsp;{{c.node.name}}
                             </a>
                             <ul class="fa-ul" *ngIf="c.children.length && !isCollapsed(c.node)">
                                 <ng-container


### PR DESCRIPTION
Small adjustment to add icons in place of blank space when an item is not nested (and would have a caret) for folders and collections.

Tweak on https://github.com/bitwarden/desktop/pull/303

![image](https://user-images.githubusercontent.com/3904944/102665054-1461a780-4152-11eb-98c1-200cb0c42e2e.png)

Companion change in web: https://github.com/bitwarden/web/pull/745