### PR TITLE
Add forcefocus as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   },
   "build": {
     "appId": "com.bitwarden.desktop",
+    "buildDependenciesFromSource": true,
     "copyright": "Copyright © 2015-2020 Bitwarden Inc.",
     "directories": {
       "buildResources": "resources",

--- a/src/package.json
+++ b/src/package.json
@@ -18,6 +18,7 @@
     "electron-log": "2.2.17",
     "electron-store": "1.3.0",
     "electron-updater": "4.3.5",
+    "forcefocus": "^1.1.0",
     "keytar": "4.13.0",
     "node-ipc": "^9.1.1",
     "zxcvbn": "4.4.2"


### PR DESCRIPTION
I forgot to add `forcefocus` as a dependency to the included packages in the dist build.

Since `forcefocus` doesn't have a prebuild package for our version of electron, I had to set `buildDepdenciesFromSource`, which I'm not certain will cause issues with building on other platforms.