### PR TITLE
Fix electron error on native messaging [Windows]

### DIFF
--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,0 +1,33 @@
+import { NativeMessagingProxy } from './proxy/native-messaging-proxy';
+
+// We need to import the other dependencies using `reqiuire` since import will
+// generate `Error: Cannot find module 'electron'`. The cause of this error is
+// due to native messaging setting the ELECTRON_RUN_AS_NODE env flag on windows
+// which removes the electron module. This flag is needed for stdin/out to work
+// properly on Windows.
+
+if (process.argv.some(arg => arg.indexOf('chrome-extension://') !== -1 || arg.indexOf('{') !== -1)) {
+    if (process.platform === 'darwin') {
+        // tslint:disable-next-line
+        const app = require('electron').app;
+
+        app.on('ready', () => {
+            app.dock.hide();
+        });
+    }
+
+    process.stdout.on('error', (e) => {
+        if (e.code === 'EPIPE') {
+            process.exit(0);
+        }
+    });
+
+    const proxy = new NativeMessagingProxy();
+    proxy.run();
+} else {
+    // tslint:disable-next-line
+    const Main = require('./main').Main;
+
+    const main = new Main();
+    main.bootstrap();
+}

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -1,6 +1,6 @@
 import { NativeMessagingProxy } from './proxy/native-messaging-proxy';
 
-// We need to import the other dependencies using `reqiuire` since import will
+// We need to import the other dependencies using `require` since `import` will
 // generate `Error: Cannot find module 'electron'`. The cause of this error is
 // due to native messaging setting the ELECTRON_RUN_AS_NODE env flag on windows
 // which removes the electron module. This flag is needed for stdin/out to work

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, globalShortcut } from 'electron';
+import { app } from 'electron';
 import * as path from 'path';
 
 import { I18nService } from './services/i18n.service';
@@ -19,7 +19,6 @@ import { TrayMain } from 'jslib/electron/tray.main';
 import { UpdaterMain } from 'jslib/electron/updater.main';
 import { WindowMain } from 'jslib/electron/window.main';
 import { NativeMessagingMain } from './main/nativeMessaging.main';
-import { NativeMessagingProxy } from './proxy/native-messaging-proxy';
 
 export class Main {
     logService: ElectronLogService;
@@ -182,24 +181,4 @@ export class Main {
             }
         });
     }
-}
-
-if (process.argv.some(arg => arg.indexOf('chrome-extension://') !== -1 || arg.indexOf('{') !== -1)) {
-    if (process.platform === 'darwin') {
-        app.on('ready', () => {
-            app.dock.hide();
-        });
-    }
-
-    process.stdout.on('error', (e) => {
-        if (e.code === 'EPIPE') {
-            process.exit(0);
-        }
-    });
-
-    const proxy = new NativeMessagingProxy();
-    proxy.run();
-} else {
-    const main = new Main();
-    main.bootstrap();
 }

--- a/webpack.main.js
+++ b/webpack.main.js
@@ -41,7 +41,7 @@ const main = {
         __filename: false,
     },
     entry: {
-        'main': './src/main.ts',
+        'main': './src/entry.ts',
     },
     optimization: {
         minimize: false,


### PR DESCRIPTION
This resolves an error where native messaging would not work on Windows when using the installed version, and not `dist/win-unpacked/Bitwarden.exe`.

The cause of the error seems to be the related to the `ELECTRON_RUN_AS_NODE=1` environment flag which is required to get stdin/out working on Windows. This efficiently tells electron to run as regular node and not load the graphical parts. Which caused the native-messaging application to error out with `Error: Cannot find module 'electron'`.

I'm not certain why this error doesn't occur on the other builds and only on the installed version, seems to me that they should all have been effected.