### PR TITLE
Fixing MacOS deploy

### DIFF
--- a/.github/scripts/macos/increment-version.ps1
+++ b/.github/scripts/macos/increment-version.ps1
@@ -1,6 +1,6 @@
 ﻿$rootPath = $env:GITHUB_WORKSPACE;
 $packagePath = "$rootPath\package.json";
-$buildNumber = 100 + [int]$env:GITHUB_RUN_NUMBER;
+$buildNumber = 500 + [int]$env:GITHUB_RUN_NUMBER;
 Write-Output "Setting build number to $buildNumber";
 Write-Output "BUILD_NUMBER=$buildNumber" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append;
 $package = Get-Content -Raw -Path $packagePath | ConvertFrom-Json;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,24 +9,9 @@ on:
 
 
 jobs:
-  cloc:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Set up cloc
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install cloc
-
-      - name: Print lines of code
-        run: cloc --include-lang TypeScript,JavaScript,HTML,Sass,CSS --vcs git
-
-
   setup:
     runs-on: ubuntu-latest
+    if: false
     outputs:
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
@@ -53,6 +38,7 @@ jobs:
 
   linux:
     runs-on: ubuntu-latest
+    if: false
     needs: setup
     steps:
       - name: Set up Node
@@ -106,6 +92,7 @@ jobs:
 
   windows:
     runs-on: windows-latest
+    if: false
     needs: setup
     steps:
       - name: Set up dotnet


### PR DESCRIPTION
## Summary
Disabling jobs that already have released successfully. Fixing the MacOS deploy

## Files Changed
- .github/workflows/release.yml
- .github/scripts/macos/increment-version.ps1