### PR TITLE
adding in the needed GITHUB_TOKEN for the publish:mac

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,6 +282,7 @@ jobs:
       - name: Build application (dist)
         run: npm run publish:mac
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
 


### PR DESCRIPTION
## Summary
Forgot to add the GITHUB_TOKEN to the env when switching to publish:mac

## Files Changed
- .github/workflows/release.yml