### PR TITLE
Distribute ARM64 executables for Windows platform.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,6 +183,8 @@ jobs:
             -Destination "./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-ia32-store.appx"
           Copy-Item "./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-x64.appx" `
             -Destination "./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-x64-store.appx"
+          Copy-Item "./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-arm64.appx" `
+            -Destination "./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-arm64-store.appx"
 
       - name: Deploy to Chocolatey
         shell: pwsh
@@ -222,6 +224,13 @@ jobs:
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-x64-store.appx
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-x64-store.appx
+
+      - name: Upload store appx ARM64 artifact
+        if: github.ref == 'refs/heads/master'
+        uses: actions/upload-artifact@v2
+        with:
+          name: Bitwarden-${{ env.PACKAGE_VERSION }}-arm64-store.appx
+          path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-arm64-store.appx
 
       - name: Upload nupkg artifact
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,6 +251,16 @@ jobs:
           asset_path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-x64.appx
           asset_content_type: application
 
+      - name: Upload unsigned ARM64 Windows Store release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.setup.outputs.release_upload_url }}
+          asset_name: Bitwarden-${{ env.PACKAGE_VERSION }}-arm64-store.appx
+          asset_path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-arm64.appx
+          asset_content_type: application
+
   macos:
     runs-on: macos-latest
     needs: setup

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "pack:mac": "npm run clean:dist && electron-builder --mac -p never",
     "pack:mac:mas": "npm run clean:dist && electron-builder --mac mas -p never",
     "pack:mac:masdev": "npm run clean:dist && electron-builder --mac mas-dev -p never",
-    "pack:win": "npm run clean:dist && electron-builder --win --x64 --ia32 -p never -c.win.certificateSubjectName=\"8bit Solutions LLC\"",
-    "pack:win:ci": "npm run clean:dist && electron-builder --win --x64 --ia32 -p never",
+    "pack:win": "npm run clean:dist && electron-builder --win --x64 --arm64 --ia32 -p never -c.win.certificateSubjectName=\"8bit Solutions LLC\"",
+    "pack:win:ci": "npm run clean:dist && electron-builder --win --x64 --arm64 --ia32 -p never",
     "dist:dir": "npm run build && npm run pack:dir",
     "dist:lin": "npm run build && npm run pack:lin",
     "dist:mac": "npm run build && npm run pack:mac",
@@ -52,7 +52,7 @@
     "publish:lin": "npm run build && npm run clean:dist && electron-builder --linux --x64 -p always",
     "publish:mac": "npm run build && npm run clean:dist && electron-builder --mac -p always",
     "publish:mac:mas": "npm run dist:mac:mas && npm run upload:mas",
-    "publish:win": "npm run build && npm run clean:dist && electron-builder --win --x64 --ia32 -p always -c.win.certificateSubjectName=\"8bit Solutions LLC\"",
+    "publish:win": "npm run build && npm run clean:dist && electron-builder --win --x64 --arm64 --ia32 -p always -c.win.certificateSubjectName=\"8bit Solutions LLC\"",
     "upload:mas": "xcrun altool --upload-app --type osx --file \"$(find ./dist/mas/Bitwarden*.pkg)\" --username $APPLE_ID_USERNAME --password $APPLE_ID_PASSWORD"
   },
   "build": {


### PR DESCRIPTION
**Problem:**
Given the native communication landed, there will be more users who run Bitwarden Desktop in background for biometrics login in extension. However, currently we only ship IA32 and AMD64 versions of Bitwarden Desktop. Though Windows provides the emulation for them, it leads to the penalty in both performance and battery life.

**Changes:**
We're currently using Electron 6.1.7 which supports ARM64 on Windows out of box. So I added the target in the build script.

**Tests:**
I tested the build output and as far as I can tell,  everything works pretty well natively:
![image](https://user-images.githubusercontent.com/8717471/105622630-f91f4180-5e4d-11eb-9ab7-a29da82ce5f9.png)

**Open Issue:**
It requires additional help from your side to make some updates in other places, such as Microsoft Store, download link in https://bitwarden.com/download/, etc..

I have an ARM64 laptop on hand(Surface Pro X). Let me know if I can help more.
