### PR TITLE
Fix menu bug and enable start to tray for Linux

### DIFF
--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -118,7 +118,7 @@
                             </div>
                             <small class="help-block">{{enableTrayDescText}}</small>
                         </div>
-                        <div class="form-group" *ngIf="showMinToTray">
+                        <div class="form-group">
                             <div class="checkbox">
                                 <label for="enableMinToTray">
                                     <input id="enableMinToTray" type="checkbox" name="EnableMinToTray"

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -38,7 +38,6 @@ export class SettingsComponent implements OnInit {
     enableMinToTray: boolean = false;
     enableCloseToTray: boolean = false;
     enableTray: boolean = false;
-    showMinToTray: boolean = false;
     startToTray: boolean = false;
     minimizeOnCopyToClipboard: boolean = false;
     locale: string;
@@ -143,7 +142,6 @@ export class SettingsComponent implements OnInit {
     }
 
     async ngOnInit() {
-        this.showMinToTray = this.platformUtilsService.getDevice() !== DeviceType.LinuxDesktop;
         this.vaultTimeout = await this.storageService.get<number>(ConstantsService.vaultTimeoutKey);
         this.vaultTimeoutAction = await this.storageService.get<string>(ConstantsService.vaultTimeoutActionKey);
         const pinSet = await this.vaultTimeoutService.isPinLockSet();

--- a/src/main/menu.main.ts
+++ b/src/main/menu.main.ts
@@ -77,11 +77,16 @@ export class MenuMain extends BaseMenu {
     }
 
     updateApplicationMenuState(isAuthenticated: boolean, isLocked: boolean) {
+
         this.unlockedRequiredMenuItems.forEach((mi: MenuItem) => {
             if (mi != null) {
                 mi.enabled = isAuthenticated && !isLocked;
             }
         });
+
+        if (this.menu != null) {
+            Menu.setApplicationMenu(this.menu);
+        }
 
         if (this.logOut != null) {
             this.logOut.enabled = isAuthenticated;


### PR DESCRIPTION
Fixes #663  which is caused by the menu not being reloaded after updating the MenuItem states. Simple fix of resetting the app menu everytime the function is called.

Also enable the start to tray for Linux and other tray related actions; is working on **Arch Linux kernel 5.4.86-1-lts** and **KDE Plasma 5.20.4**; the options still exist and function if entered into the config file manually, so I do not think there is a reason to not just show the buttons. Although I have not tested in other desktop environments or distributions.