### PR TITLE
Add entitlements to mac, disable browser integration on Windows Store

### DIFF
--- a/resources/entitlements.mas.plist
+++ b/resources/entitlements.mas.plist
@@ -8,5 +8,10 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
+	<key>com.apple.security.temporary-exception.files.home-relative-path.read-write</key>
+	<array>
+		<string>/Library/Application Support/Mozilla/NativeMessagingHosts/</string>
+		<string>/Library/Application Support/Google/Chrome/NativeMessagingHosts/</string>
+	</array>
 </dict>
 </plist>

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -23,6 +23,7 @@ import { ConstantsService } from 'jslib/services/constants.service';
 import { ElectronConstants } from 'jslib/electron/electronConstants';
 
 import { Utils } from 'jslib/misc/utils';
+import { isWindowsStore } from 'jslib/electron/utils';
 
 @Component({
     selector: 'app-settings',
@@ -354,6 +355,14 @@ export class SettingsComponent implements OnInit {
             await this.platformUtilsService.showDialog(
                 this.i18nService.t('browserIntegrationMasOnlyDesc'),
                 this.i18nService.t('browserIntegrationMasOnlyTitle'),
+                this.i18nService.t('ok'), null, 'warning');
+
+            this.enableBrowserIntegration = false;
+            return;
+        } else if (isWindowsStore()) {
+            await this.platformUtilsService.showDialog(
+                this.i18nService.t('browserIntegrationWindowsStoreDesc'),
+                this.i18nService.t('browserIntegrationWindowsStoreTitle'),
                 this.i18nService.t('ok'), null, 'warning');
 
             this.enableBrowserIntegration = false;

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1462,6 +1462,12 @@
   "browserIntegrationMasOnlyDesc": {
     "message": "Unfortunately browser integration is only supported in the Mac App Store version for now."
   },
+  "browserIntegrationWindowsStoreTitle": {
+    "message": "Browser integration not supported"
+  },
+  "browserIntegrationWindowsStoreDesc": {
+    "message": "Unfortunately browser integration is currently not supported in the Windows Store version."
+  },
   "enableBrowserIntegrationFingerprint": {
     "message": "Require verification for browser integration"
   },


### PR DESCRIPTION
Adds the missing entitlements to the MAS version, which should resolve browser integration not working on Mac. (This is untested since I haven't found any way test it locally)

Also disables browser integration in the Windows Store version for now. There are potential workarounds we could investigate but they are complex and some would require special approval to publish in the Microsoft Store.

![image](https://user-images.githubusercontent.com/137855/105716768-95fddf80-5f1f-11eb-99ee-2bbec1f49487.png)