### PR TITLE
Automatic handling of Release Tag Name input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Release
 on:
   workflow_dispatch:
     inputs:
-      release_tag_name:
-        description: 'Release Tag Name (vX.X.X)'
+      release_tag_name_input:
+        description: 'Release Tag Name <X.X.X>'
         required: true
       browser_extension_ref:
         description: 'Browser Extension ref (defaults to `master`):'
@@ -20,11 +20,24 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
-      - name: Create Release Name
+      - name: Create Release Vars
+        id: create_tags
         run: |
-          echo "RELEASE_NAME=${RELEASE_TAG_NAME:1}" >> $GITHUB_ENV
+          case "${RELEASE_TAG_NAME_INPUT:0:1}" in
+            v)
+              echo "RELEASE_NAME=${RELEASE_TAG_NAME_INPUT:1}" >> $GITHUB_ENV
+              echo "RELEASE_TAG_NAME=$RELEASE_TAG_NAME_INPUT" >> $GITHUB_ENV
+              ;;
+            [0-9])
+              echo "RELEASE_NAME=$RELEASE_TAG_NAME_INPUT" >> $GITHUB_ENV
+              echo "RELEASE_TAG_NAME=v$RELEASE_TAG_NAME_INPUT" >> $GITHUB_ENV
+              ;;
+            *)
+              exit 1
+              ;;
+          esac
         env:
-          RELEASE_TAG_NAME: ${{ github.event.inputs.release_tag_name }}
+          RELEASE_TAG_NAME_INPUT: ${{ github.event.inputs.release_tag_name_input }}
 
       - name: Create Draft Release
         id: create_release
@@ -32,7 +45,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.event.inputs.release_tag_name }}
+          tag_name: ${{ env.RELEASE_TAG_NAME }}
           release_name: ${{ env.RELEASE_NAME }}
           draft: true
           prerelease: false


### PR DESCRIPTION
## Summary
Adding in automatic checks and env var assignments to create the draft release with either vX.X.X or X.X.X for the release tag name input to the release workflow.

## Files Changed
- .github/workflows/release.yml