### PR TITLE
Only change socketRoot on mac

### DIFF
--- a/src/main/nativeMessaging.main.ts
+++ b/src/main/nativeMessaging.main.ts
@@ -17,7 +17,9 @@ export class NativeMessagingMain {
     listen() {
         ipc.config.id = 'bitwarden';
         ipc.config.retry = 1500;
-        ipc.config.socketRoot = path.join(homedir(), 'tmp');
+        if (process.platform === 'darwin') {
+            ipc.config.socketRoot = path.join(homedir(), 'tmp');
+        }
 
         ipc.serve(() => {
             ipc.server.on('message', (data: any, socket: any) => {

--- a/src/proxy/ipc.ts
+++ b/src/proxy/ipc.ts
@@ -6,7 +6,9 @@ import * as path from 'path';
 ipc.config.id = 'proxy';
 ipc.config.retry = 1500;
 ipc.config.logger = console.warn; // Stdout is used for native messaging
-ipc.config.socketRoot = path.join(homedir(), 'tmp');
+if (process.platform === 'darwin') {
+    ipc.config.socketRoot = path.join(homedir(), 'tmp');
+}
 
 export default class IPC {
     onMessage: (message: object) => void


### PR DESCRIPTION
While it still works fine on Windows, it results in a slightly odd name for the Named Pipe, so we might as well use the default on non Mac environments.