### PR TITLE
Add trailing slash to ipc.config.socketRoot

### DIFF
--- a/src/main/nativeMessaging.main.ts
+++ b/src/main/nativeMessaging.main.ts
@@ -18,7 +18,7 @@ export class NativeMessagingMain {
         ipc.config.id = 'bitwarden';
         ipc.config.retry = 1500;
         if (process.platform === 'darwin') {
-            ipc.config.socketRoot = path.join(homedir(), 'tmp');
+            ipc.config.socketRoot = `${homedir()}/tmp/`;
         }
 
         ipc.serve(() => {

--- a/src/proxy/ipc.ts
+++ b/src/proxy/ipc.ts
@@ -1,13 +1,12 @@
 /* tslint:disable:no-console */
 import * as ipc from 'node-ipc';
 import { homedir } from 'os';
-import * as path from 'path';
 
 ipc.config.id = 'proxy';
 ipc.config.retry = 1500;
 ipc.config.logger = console.warn; // Stdout is used for native messaging
 if (process.platform === 'darwin') {
-    ipc.config.socketRoot = path.join(homedir(), 'tmp');
+    ipc.config.socketRoot = `${homedir()}/tmp/`;
 }
 
 export default class IPC {


### PR DESCRIPTION
While browser biometric is now working on Mac, we have a slightly odd path for the socket file since `ipc.config.socketRoot` expects a trailing slash.