### PR TITLE
Fix electron 11 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
       "entitlementsInherit": "resources/entitlements.mas.inherit.plist",
       "hardenedRuntime": false,
       "asarUnpack": [
-        "node_modules/desktop-idle",
         "node_modules/keytar"
       ]
     },
@@ -308,13 +307,12 @@
     "big-integer": "1.6.36",
     "browser-hrtime": "^1.1.8",
     "core-js": "2.6.2",
-    "desktop-idle": "1.1.2",
     "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
     "electron-log": "4.3.0",
     "electron-store": "6.0.1",
     "electron-updater": "4.3.5",
     "forcefocus": "^1.1.0",
-    "keytar": "4.13.0",
+    "keytar": "7.3.0",
     "lunr": "2.3.3",
     "node-forge": "0.7.6",
     "node-ipc": "^9.1.1",

--- a/src/main/powerMonitor.main.ts
+++ b/src/main/powerMonitor.main.ts
@@ -7,7 +7,6 @@ import { isSnapStore } from 'jslib/electron/utils';
 import { Main } from '../main';
 
 // tslint:disable-next-line
-const desktopIdle = require('desktop-idle');
 const IdleLockSeconds = 5 * 60; // 5 minutes
 const IdleCheckInterval = 30 * 1000; // 30 seconds
 
@@ -42,7 +41,7 @@ export class PowerMonitorMain {
 
         // System idle
         global.setInterval(async () => {
-            const idleSeconds: number = desktopIdle.getIdleTime();
+            const idleSeconds: number = powerMonitor.getSystemIdleTime();
             const idle = idleSeconds >= IdleLockSeconds;
             if (idle) {
                 if (this.idle) {

--- a/src/package.json
+++ b/src/package.json
@@ -14,15 +14,14 @@
   "dependencies": {
     "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
     "big-integer": "1.6.36",
-    "desktop-idle": "1.1.2",
+    "browser-hrtime": "^1.1.8",
     "electron-log": "4.3.0",
     "electron-store": "6.0.1",
     "electron-updater": "4.3.5",
     "forcefocus": "^1.1.0",
-    "keytar": "4.13.0",
+    "keytar": "7.3.0",
     "node-ipc": "^9.1.1",
     "regedit": "^3.0.3",
-    "zxcvbn": "4.4.2",
-    "browser-hrtime": "^1.1.8"
+    "zxcvbn": "4.4.2"
   }
 }


### PR DESCRIPTION
Bitwarden has updates its electron dependency to 11 the other day. However, 
- keytar is an old version that doesn't support electron 11
- desktop-idle doesn't support electron 11 by far

So it leads to the problem https://github.com/flathub/com.bitwarden.desktop/pull/52#issuecomment-772369527

This PR updates keytar to the latest release and replaces desktop-idle with [powerMonitor.getSystemIdleTime()](https://www.electronjs.org/docs/api/power-monitor#powermonitorgetsystemidletime)