### PR TITLE
Fixed menu reloading bug

### DIFF
--- a/src/main/menu.main.ts
+++ b/src/main/menu.main.ts
@@ -83,6 +83,10 @@ export class MenuMain extends BaseMenu {
             }
         });
 
+        if (this.menu != null) {
+            Menu.setApplicationMenu(this.menu);
+        }
+
         if (this.logOut != null) {
             this.logOut.enabled = isAuthenticated;
         }


### PR DESCRIPTION
Fixes #663 which is caused by the menu not being reloaded after updating the MenuItem states. Simple fix of resetting the app menu everytime the function is called.

Previously #673 but with the tray menu aspect removed.