### PR TITLE
Allowed editing sends

### DIFF
--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -1,97 +1,106 @@
-<div class="content" *ngIf="send">
-    <div class="inner-content">
-        <div class="box">
-            <div class="box-header">
-                {{'editSend' | i18n}}
-            </div>
-            <div class="box-content">
-                <div class="box-content-row" appBoxRow>
-                    <label for="name">{{'name' | i18n}}</label>
-                    <input id="name" type="text" name="Name" [(ngModel)]="send.name" appAutofocus>
+<ng-container *ngIf="send">
+    <form (ngSubmit)="submit()" [appApiAction]="formPromise">
+        <div class="content" *ngIf="send">
+            <div class="inner-content">
+                <div class="box">
+                    <div class="box-header">
+                        {{'editSend' | i18n}}
+                    </div>
+                    <div class="box-content">
+                        <div class="box-content-row" appBoxRow>
+                            <label for="name">{{'name' | i18n}}</label>
+                            <input id="name" type="text" name="Name" [(ngModel)]="send.name" appAutofocus>
+                        </div>
+                        <div class="box-content-row" appBoxRow *ngIf="send.type === sendType.File">
+                            <label for="file">{{'file' | i18n}}</label>
+                            <input id="file" type="text" name="file" [(ngModel)]="send.file.fileName" readonly>
+                        </div>
+                        <div class="box-content-row" appBoxRow *ngIf="send.type === sendType.Text">
+                            <label for="text">{{'text' | i18n}}</label>
+                            <input id="text" type="text" name="text" [(ngModel)]="send.text.text">
+                        </div>
+                        <div class="box-content-row box-content-row-checkbox" appBoxRow *ngIf="send.type === sendType.Text">
+                            <label for="hideText">{{'textHiddenByDefault' | i18n}}</label>
+                            <input id="hideText" name="hideText" type="checkbox" [(ngModel)]="send.text.hidden">
+                        </div>
+                    </div>
                 </div>
-                <div class="box-content-row" appBoxRow *ngIf="send.type === sendType.File">
-                    <label for="file">{{'file' | i18n}}</label>
-                    <input id="file" type="text" name="file" [(ngModel)]="send.file.fileName" readonly>
+                <div class="box">
+                    <div class="box-header">
+                        {{'options' | i18n}}
+                    </div>
+                    <div class="box-content">
+                        <div class="box-content-row" appBoxRow *ngIf="editMode">
+                            <label for="deletionDate">{{'deletionDate' | i18n}}</label>
+                            <input id="deletionDate" type="datetime-local" name="deletionDate"
+                                [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM">
+                            <div class="subtext">{{'deletionDateDesc' | i18n}}</div>
+                        </div>
+                        <div class="box-content-row" appBoxRow>
+                            <label for="expirationDate">{{'expirationDate' | i18n}}</label>
+                            <input id="expirationDate" type="datetime-local" name="expirationDate" [(ngModel)]="expirationDate">
+                            <div class="subtext">{{'expirationDateDesc' | i18n}}</div>
+                        </div>
+                    </div>
                 </div>
-                <div class="box-content-row" appBoxRow *ngIf="send.type === sendType.Text">
-                    <label for="text">{{'text' | i18n}}</label>
-                    <input id="text" type="text" name="text" [(ngModel)]="send.text.text">
+                <div class="box">
+                    <div class="box-content">
+                        <div class="box-content-row" appBoxRow>
+                            <label for="maxAccessCount">{{'maxAccessCount' | i18n}}</label>
+                            <input id="maxAccessCount" type="number" name="maxAccessCount" [(ngModel)]="send.maxAccessCount">
+                            <div class="subtext">{{'maxAccessCountDesc' | i18n}}</div>
+                        </div>
+                        <div class="box-content-row" appBoxRow>
+                            <label for="accessCount">{{'currentAccessCount' | i18n}}</label>
+                            <input id="accessCount" type="text" name="accessCount" [(ngModel)]="send.accessCount" readonly>
+                        </div>
+                    </div>
                 </div>
-                <div class="box-content-row box-content-row-checkbox" appBoxRow *ngIf="send.type === sendType.Text">
-                    <label for="hideText">{{'textHiddenByDefault' | i18n}}</label>
-                    <input id="hideText" name="hideText" type="checkbox" [(ngModel)]="send.text.hidden">
+                <div class="box">
+                    <div class="box-content">
+                        <div class="box-content-row" appBoxRow>
+                            <label for="password">{{(hasPassword ? 'newPassword' : 'password') | i18n}}</label>
+                            <input id="password" type="password" name="password" [(ngModel)]="password">
+                            <div class="subtext">{{'sendPasswordDesc' | i18n}}</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="box">
+                    <div class="box-header">
+                        {{'notes' | i18n}}
+                    </div>
+                    <div class="box-content">
+                        <div class="box-content-row" appBoxRow>
+                            <textarea id="notes" name="notes" [(ngModel)]="send.notes" rows="6"></textarea>
+                            <small class="subtext">{{'sendNotesDesc' | i18n}}</small>
+                        </div>
+                    </div>
+                </div>
+                <div class="box">
+                    <div class="box-content">
+                        <div class="box-content-row box-content-row-checkbox" appBoxRow>
+                            <label for="disabled">{{'disableSend' | i18n}}</label>
+                            <input id="disabled" type="checkbox" name="disabled" [(ngModel)]="send.disabled">
+                        </div>
+                    </div>
+                </div>
+                <div class="box">
+                    <div class="box-header">
+                        {{'share' | i18n}}
+                    </div>
+                    <div class="box-content">
+                        <div class="box-content-row" appBoxRow>
+                            <label for="url">{{'sendLink' | i18n}}</label>
+                            <input id="url" name="url" [ngModel]="link" readonly>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
-        <div class="box">
-            <div class="box-header">
-                {{'options' | i18n}}
-            </div>
-            <div class="box-content">
-                <div class="box-content-row" appBoxRow *ngIf="editMode">
-                    <label for="deletionDate">{{'deletionDate' | i18n}}</label>
-                    <input id="deletionDate" type="datetime-local" name="deletionDate"
-                        [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM">
-                    <div class="subtext">{{'deletionDateDesc' | i18n}}</div>
-                </div>
-                <div class="box-content-row" appBoxRow>
-                    <label for="expirationDate">{{'expirationDate' | i18n}}</label>
-                    <input id="expirationDate" type="datetime-local" name="expirationDate" [(ngModel)]="send.expirationDate">
-                    <div class="subtext">{{'expirationDateDesc' | i18n}}</div>
-                </div>
-            </div>
+        <div class="footer">
+            <button appBlurClick type="submit" class="primary" appA11yTitle="{{'save' | i18n}}">
+                <i class="fa fa-save fa-lg fa-fw" aria-hidden="true"></i>
+            </button>
         </div>
-        <div class="box">
-            <div class="box-content">
-                <div class="box-content-row" appBoxRow>
-                    <label for="maxAccessCount">{{'maxAccessCount' | i18n}}</label>
-                    <input id="maxAccessCount" type="number" name="maxAccessCount" [(ngModel)]="send.maxAccessCount">
-                    <div class="subtext">{{'maxAccessCountDesc' | i18n}}</div>
-                </div>
-                <div class="box-content-row" appBoxRow>
-                    <label for="accessCount">{{'currentAccessCount' | i18n}}</label>
-                    <input id="accessCount" type="text" name="accessCount" [(ngModel)]="send.accessCount" readonly>
-                </div>
-            </div>
-        </div>
-        <div class="box">
-            <div class="box-content">
-                <div class="box-content-row" appBoxRow>
-                    <label for="password">{{'password' | i18n}}</label>
-                    <input id="password" type="password" name="password" [(ngModel)]="send.password">
-                    <div class="subtext">{{'sendPasswordDesc' | i18n}}</div>
-                </div>
-            </div>
-        </div>
-        <div class="box">
-            <div class="box-header">
-                {{'notes' | i18n}}
-            </div>
-            <div class="box-content">
-                <div class="box-content-row" appBoxRow>
-                    <textarea id="notes" name="notes" [(ngModel)]="send.notes" rows="6"></textarea>
-                    <small class="subtext">{{'sendNotesDesc' | i18n}}</small>
-                </div>
-            </div>
-        </div>
-        <div class="box">
-            <div class="box-content">
-                <div class="box-content-row box-content-row-checkbox" appBoxRow>
-                    <label for="disabled">{{'disableSend' | i18n}}</label>
-                    <input id="disabled" type="checkbox" name="disabled" [(ngModel)]="send.disabled">
-                </div>
-            </div>
-        </div>
-        <div class="box">
-            <div class="box-header">
-                {{'share' | i18n}}
-            </div>
-            <div class="box-content">
-                <div class="box-content-row" appBoxRow>
-                    <label for="url">{{'sendLink' | i18n}}</label>
-                    <input id="url" name="url" [ngModel]="link" readonly>
-                </div>
-            </div>
-        </div>
-    </div>
-</div>
+    </form>
+</ng-container>

--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -28,5 +28,9 @@ export class AddEditComponent extends BaseAddEditComponent {
     async refresh() {
         const send = await this.loadSend();
         this.send = await send.decrypt();
+        this.hasPassword = this.send.password != null && this.send.password.trim() !== '';
+        this.deletionDate = this.dateToString(this.send.deletionDate);
+        this.expirationDate = this.dateToString(this.send.expirationDate);
+        this.password = null;
     }
 }

--- a/src/app/send/send.component.html
+++ b/src/app/send/send.component.html
@@ -67,7 +67,7 @@
             </button>
         </div>
     </div>
-    <app-send-add-edit id="addEdit" class="details" *ngIf="action == 'add' || action == 'edit'" [sendId]="sendId" [type]="selectedSendType"></app-send-add-edit>
+    <app-send-add-edit id="addEdit" class="details" *ngIf="action == 'add' || action == 'edit'" [sendId]="sendId" [type]="selectedSendType" (onSavedSend)="refresh()"></app-send-add-edit>
     <div class="logo" *ngIf="!action">
         <div class="content">
             <div class="inner-content">

--- a/src/app/send/send.component.ts
+++ b/src/app/send/send.component.ts
@@ -72,6 +72,6 @@ export class SendComponent extends BaseSendComponent implements OnInit {
     }
 
     get selectedSendType() {
-        return this.sends.find(s => s.id === this.sendId).type;
+        return this.sends.find(s => s.id === this.sendId)?.type;
     }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1568,5 +1568,20 @@
   "textHiddenByDefault": {
     "message": "When accessing the Send, hide the text by default",
     "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "createdSend": {
+    "message": "Created Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "editedSend": {
+    "message": "Edited Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "deletedSend": {
+    "message": "Deleted Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "newPassword": {
+    "message": "New Password"
   }
 }


### PR DESCRIPTION
## Objective
> Create a functional and good UI for Bitwarden Send on desktop

## Code Changes
- **send/add-edit.component.html**: Wrapped everything in a `<ng-container>` and `<form>` that ties in to the `jslib` `submit()` logic. Added a `.footer` with a submit button identical to the `.footer` shown when editing a Vault item. 
- **send/add-edit.component.ts**: Added some logic to `refresh()` for fields we mess with before displaying information. The previous method was keeping some fields from updating when swapping between selected Sends.
- **send/send.component.html**: Added a hook to the Send edited method to refresh the Send list.
- **send/send.component.ts**: Did a null check to stop a console error.
- **en/messages.json**: Copied a few more strings from `web`.

## Testing Considerations
- This PR adds the ability to edit sends that already exist from other clients. Deleting & creating Sends in Desktop is not yet supported.