### PR TITLE
Finished CRUD operations for Send

### DIFF
--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -67,7 +67,7 @@
                         </select>
                         <div class="subtext">{{'deletionDateDesc' | i18n}}</div>
                     </div>
-                    <div class="box-content-row" *ngIf="deletionDateSelect === 0">
+                    <div class="box-content-row" *ngIf="deletionDateSelect === 0 && !editMode">
                         <input id="deletionDateCustom" type="datetime-local" name="deletionDate" 
                             [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM" [readOnly]="disableSend">
                     </div>
@@ -80,7 +80,7 @@
                         </select>
                         <div class="subtext">{{'expirationDateDesc' | i18n}}</div>
                     </div>
-                    <div class="box-content-row" *ngIf="expirationDateSelect === 0">
+                    <div class="box-content-row" *ngIf="expirationDateSelect === 0 && !editMode">
                         <input id="expirationDateCustom" type="datetime-local" name="expirationDate" 
                             [(ngModel)]="expirationDate" required placeholder="MM/DD/YYYY HH:MM AM/PM" [readOnly]="disableSend">
                     </div>

--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -1,106 +1,159 @@
-<ng-container *ngIf="send">
-    <form (ngSubmit)="submit()" [appApiAction]="formPromise">
-        <div class="content" *ngIf="send">
-            <div class="inner-content">
-                <div class="box">
-                    <div class="box-header">
-                        {{'editSend' | i18n}}
+<form (ngSubmit)="submit()" [appApiAction]="formPromise">
+    <div class="content">
+        <div class="inner-content" *ngIf="send">
+            <div class="box">
+                <div class="box-header">
+                    {{title}}
+                </div>
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <label for="name">{{'name' | i18n}}</label>
+                        <input id="name" type="text" name="Name" [(ngModel)]="send.name" appAutofocus>
                     </div>
-                    <div class="box-content">
-                        <div class="box-content-row" appBoxRow>
-                            <label for="name">{{'name' | i18n}}</label>
-                            <input id="name" type="text" name="Name" [(ngModel)]="send.name" appAutofocus>
+                </div>
+            </div>
+            <div class="box">
+                <div class="box-content">
+                    <ng-container *ngIf="!editMode">
+                        <div class="box-content-row box-content-row-radio">
+                            <label class="radio-header">{{'whatTypeOfSend' | i18n}}</label>
+                            <div class="item" *ngFor="let o of typeOptions">
+                                <input type="radio" class="radio" [(ngModel)]="send.type" name="Type_{{o.value}}"
+                                    id="type_{{o.value}}" [value]="o.value" (change)="typeChanged(o)"
+                                    [checked]="send.type === o.value">
+                                <label class="label-hack" for="type_{{o.value}}">
+                                    {{o.name}}
+                                </label>
+                            </div>
                         </div>
-                        <div class="box-content-row" appBoxRow *ngIf="send.type === sendType.File">
+                        <div *ngIf="send.type === sendType.File" class="box-content-row" appBowRow>
+                            <label for="file">{{'file' | i18n}}</label>
+                            <input type="file" id="file" class="form-control-file" name="file" required
+                                [disabled]="disableSend">
+                            <div class="subtext">{{'sendFileDesc' | i18n}} {{'maxFileSize' | i18n}}</div>
+                        </div>
+                    </ng-container>
+                    <ng-container *ngIf="editMode && send.type === sendType.File">
+                        <div class="box-content-row" appBoxRow>
                             <label for="file">{{'file' | i18n}}</label>
                             <input id="file" type="text" name="file" [(ngModel)]="send.file.fileName" readonly>
                         </div>
+                    </ng-container>
+                    <ng-container *ngIf="send.type === sendType.Text">
                         <div class="box-content-row" appBoxRow *ngIf="send.type === sendType.Text">
                             <label for="text">{{'text' | i18n}}</label>
-                            <input id="text" type="text" name="text" [(ngModel)]="send.text.text">
+                            <textarea id="text" name="text" [(ngModel)]="send.text.text" rows="6"></textarea>
+                            <div class="subtext">{{'sendTextDesc' | i18n}}</div>
                         </div>
                         <div class="box-content-row box-content-row-checkbox" appBoxRow *ngIf="send.type === sendType.Text">
                             <label for="hideText">{{'textHiddenByDefault' | i18n}}</label>
                             <input id="hideText" name="hideText" type="checkbox" [(ngModel)]="send.text.hidden">
                         </div>
+                    </ng-container>
+                </div>
+            </div>
+            <div class="box">
+                <div class="box-header">
+                    {{'options' | i18n}}
+                </div>
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <label for="deletionDate">{{'deletionDate' | i18n}}</label>
+                        <input id="deletionDate" type="datetime-local" name="deletionDate"
+                            [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM" *ngIf="editMode">
+                        <select id="deletionDate" name="DeletionDateSelect" [(ngModel)]="deletionDateSelect" required *ngIf="!editMode">
+                            <option *ngFor="let o of deletionDateOptions" [ngValue]="o.value">{{o.name}}
+                            </option>
+                        </select>
+                        <div class="subtext">{{'deletionDateDesc' | i18n}}</div>
+                    </div>
+                    <div class="box-content-row" *ngIf="deletionDateSelect === 0">
+                        <input id="deletionDateCustom" type="datetime-local" name="deletionDate" 
+                            [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM" [readOnly]="disableSend">
+                    </div>
+                    <div class="box-content-row" appBoxRow>
+                        <label for="expirationDate">{{'expirationDate' | i18n}}</label>
+                        <input id="expirationDate" type="datetime-local" name="expirationDate" [(ngModel)]="expirationDate" *ngIf="editMode">
+                        <select id="expirationDate" name="expirationDateSelect" [(ngModel)]="expirationDateSelect" required *ngIf="!editMode">
+                            <option *ngFor="let o of expirationDateOptions" [ngValue]="o.value">{{o.name}}
+                            </option>
+                        </select>
+                        <div class="subtext">{{'expirationDateDesc' | i18n}}</div>
+                    </div>
+                    <div class="box-content-row" *ngIf="expirationDateSelect === 0">
+                        <input id="expirationDateCustom" type="datetime-local" name="expirationDate" 
+                            [(ngModel)]="expirationDate" required placeholder="MM/DD/YYYY HH:MM AM/PM" [readOnly]="disableSend">
                     </div>
                 </div>
-                <div class="box">
-                    <div class="box-header">
-                        {{'options' | i18n}}
+            </div>
+            <div class="box">
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <label for="maxAccessCount">{{'maxAccessCount' | i18n}}</label>
+                        <input id="maxAccessCount" type="number" name="maxAccessCount" [(ngModel)]="send.maxAccessCount">
+                        <div class="subtext">{{'maxAccessCountDesc' | i18n}}</div>
                     </div>
-                    <div class="box-content">
-                        <div class="box-content-row" appBoxRow *ngIf="editMode">
-                            <label for="deletionDate">{{'deletionDate' | i18n}}</label>
-                            <input id="deletionDate" type="datetime-local" name="deletionDate"
-                                [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM">
-                            <div class="subtext">{{'deletionDateDesc' | i18n}}</div>
-                        </div>
-                        <div class="box-content-row" appBoxRow>
-                            <label for="expirationDate">{{'expirationDate' | i18n}}</label>
-                            <input id="expirationDate" type="datetime-local" name="expirationDate" [(ngModel)]="expirationDate">
-                            <div class="subtext">{{'expirationDateDesc' | i18n}}</div>
-                        </div>
+                    <div *ngIf="editMode" class="box-content-row" appBoxRow>
+                        <label for="accessCount">{{'currentAccessCount' | i18n}}</label>
+                        <input id="accessCount" type="text" name="accessCount" [(ngModel)]="send.accessCount" readonly>
                     </div>
                 </div>
-                <div class="box">
-                    <div class="box-content">
-                        <div class="box-content-row" appBoxRow>
-                            <label for="maxAccessCount">{{'maxAccessCount' | i18n}}</label>
-                            <input id="maxAccessCount" type="number" name="maxAccessCount" [(ngModel)]="send.maxAccessCount">
-                            <div class="subtext">{{'maxAccessCountDesc' | i18n}}</div>
-                        </div>
-                        <div class="box-content-row" appBoxRow>
-                            <label for="accessCount">{{'currentAccessCount' | i18n}}</label>
-                            <input id="accessCount" type="text" name="accessCount" [(ngModel)]="send.accessCount" readonly>
-                        </div>
+            </div>
+            <div class="box">
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <label for="password">{{(hasPassword ? 'newPassword' : 'password') | i18n}}</label>
+                        <input id="password" type="password" name="password" [(ngModel)]="password">
+                        <div class="subtext">{{'sendPasswordDesc' | i18n}}</div>
                     </div>
                 </div>
-                <div class="box">
-                    <div class="box-content">
-                        <div class="box-content-row" appBoxRow>
-                            <label for="password">{{(hasPassword ? 'newPassword' : 'password') | i18n}}</label>
-                            <input id="password" type="password" name="password" [(ngModel)]="password">
-                            <div class="subtext">{{'sendPasswordDesc' | i18n}}</div>
-                        </div>
+            </div>
+            <div class="box">
+                <div class="box-header">
+                    {{'notes' | i18n}}
+                </div>
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <textarea id="notes" name="notes" [(ngModel)]="send.notes" rows="6"></textarea>
+                        <small class="subtext">{{'sendNotesDesc' | i18n}}</small>
                     </div>
                 </div>
-                <div class="box">
-                    <div class="box-header">
-                        {{'notes' | i18n}}
-                    </div>
-                    <div class="box-content">
-                        <div class="box-content-row" appBoxRow>
-                            <textarea id="notes" name="notes" [(ngModel)]="send.notes" rows="6"></textarea>
-                            <small class="subtext">{{'sendNotesDesc' | i18n}}</small>
-                        </div>
+            </div>
+            <div class="box">
+                <div class="box-content">
+                    <div class="box-content-row box-content-row-checkbox" appBoxRow>
+                        <label for="disabled">{{'disableSend' | i18n}}</label>
+                        <input id="disabled" type="checkbox" name="disabled" [(ngModel)]="send.disabled">
                     </div>
                 </div>
-                <div class="box">
-                    <div class="box-content">
-                        <div class="box-content-row box-content-row-checkbox" appBoxRow>
-                            <label for="disabled">{{'disableSend' | i18n}}</label>
-                            <input id="disabled" type="checkbox" name="disabled" [(ngModel)]="send.disabled">
-                        </div>
-                    </div>
+            </div>
+            <div class="box" *ngIf="editMode">
+                <div class="box-header">
+                    {{'share' | i18n}}
                 </div>
-                <div class="box">
-                    <div class="box-header">
-                        {{'share' | i18n}}
-                    </div>
-                    <div class="box-content">
-                        <div class="box-content-row" appBoxRow>
-                            <label for="url">{{'sendLink' | i18n}}</label>
-                            <input id="url" name="url" [ngModel]="link" readonly>
-                        </div>
+                <div class="box-content">
+                    <div class="box-content-row" appBoxRow>
+                        <label for="url">{{'sendLink' | i18n}}</label>
+                        <input id="url" name="url" [ngModel]="link" readonly>
                     </div>
                 </div>
             </div>
         </div>
-        <div class="footer">
-            <button appBlurClick type="submit" class="primary" appA11yTitle="{{'save' | i18n}}">
-                <i class="fa fa-save fa-lg fa-fw" aria-hidden="true"></i>
+    </div>
+    <div class="footer">
+        <button appBlurClick type="submit" class="primary" appA11yTitle="{{'save' | i18n}}">
+            <i class="fa fa-save fa-lg fa-fw" aria-hidden="true"></i>
+        </button>
+        <button appBlurClick type="button" (click)="cancel()">
+            {{'cancel' | i18n}}
+        </button>
+        <div class="right">
+            <button #deleteBtn appBlurClick type="button" (click)="delete()" class="danger"
+                appA11yTitle="{{'delete' | i18n}}" *ngIf="editMode" [disabled]="deleteBtn.loading"
+                [appApiAction]="deletePromise">
+                <i class="fa fa-trash-o fa-lg fa-fw" [hidden]="deleteBtn.loading" aria-hidden="true"></i>
+                <i class="fa fa-spinner fa-spin fa-lg fa-fw" [hidden]="!deleteBtn.loading" aria-hidden="true"></i>
             </button>
         </div>
-    </form>
-</ng-container>
+    </div>
+</form>

--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -28,8 +28,7 @@
                         </div>
                         <div *ngIf="send.type === sendType.File" class="box-content-row" appBowRow>
                             <label for="file">{{'file' | i18n}}</label>
-                            <input type="file" id="file" class="form-control-file" name="file" required
-                                [disabled]="disableSend">
+                            <input type="file" id="file" class="form-control-file" name="file" required>
                             <div class="subtext">{{'sendFileDesc' | i18n}} {{'maxFileSize' | i18n}}</div>
                         </div>
                     </ng-container>
@@ -69,7 +68,7 @@
                     </div>
                     <div class="box-content-row" *ngIf="deletionDateSelect === 0 && !editMode">
                         <input id="deletionDateCustom" type="datetime-local" name="deletionDate" 
-                            [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM" [readOnly]="disableSend">
+                            [(ngModel)]="deletionDate" required placeholder="MM/DD/YYYY HH:MM AM/PM">
                     </div>
                     <div class="box-content-row" appBoxRow>
                         <label for="expirationDate">{{'expirationDate' | i18n}}</label>
@@ -82,7 +81,7 @@
                     </div>
                     <div class="box-content-row" *ngIf="expirationDateSelect === 0 && !editMode">
                         <input id="expirationDateCustom" type="datetime-local" name="expirationDate" 
-                            [(ngModel)]="expirationDate" required placeholder="MM/DD/YYYY HH:MM AM/PM" [readOnly]="disableSend">
+                            [(ngModel)]="expirationDate" required placeholder="MM/DD/YYYY HH:MM AM/PM">
                     </div>
                 </div>
             </div>

--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -26,11 +26,10 @@ export class AddEditComponent extends BaseAddEditComponent {
     }
 
     async refresh() {
+        this.password = null;
         const send = await this.loadSend();
         this.send = await send.decrypt();
-
         this.hasPassword = this.send.password != null && this.send.password.trim() !== '';
-
         this.deletionDate = this.dateToString(this.send.deletionDate);
         this.expirationDate = this.dateToString(this.send.expirationDate);
     }

--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -28,9 +28,14 @@ export class AddEditComponent extends BaseAddEditComponent {
     async refresh() {
         const send = await this.loadSend();
         this.send = await send.decrypt();
+
         this.hasPassword = this.send.password != null && this.send.password.trim() !== '';
+
         this.deletionDate = this.dateToString(this.send.deletionDate);
         this.expirationDate = this.dateToString(this.send.expirationDate);
-        this.password = null;
+    }
+
+    cancel() {
+        this.onCancelled.emit(this.send);
     }
 }

--- a/src/app/send/send.component.html
+++ b/src/app/send/send.component.html
@@ -67,7 +67,8 @@
             </button>
         </div>
     </div>
-    <app-send-add-edit id="addEdit" class="details" *ngIf="action == 'add' || action == 'edit'" [sendId]="sendId" [type]="selectedSendType" (onSavedSend)="refresh()"></app-send-add-edit>
+    <app-send-add-edit id="addEdit" class="details" *ngIf="action == 'add' || action == 'edit'" [sendId]="sendId" [type]="selectedSendType" 
+        (onSavedSend)="refresh()" (onCancelled)="cancel()"></app-send-add-edit>
     <div class="logo" *ngIf="!action">
         <div class="content">
             <div class="inner-content">

--- a/src/app/send/send.component.html
+++ b/src/app/send/send.component.html
@@ -43,7 +43,7 @@
                 [infiniteScrollContainer]="'#items .content'" [fromRoot]="true" (scrolled)="loadMore()">
                 <a *ngFor="let s of filteredSends" appStopClick (click)="selectSend(s.id)"
                     href="#" title="{{'viewItem' | i18n}}"
-                    [ngClass]="{'active': s.id === activeSendId}">
+                    [ngClass]="{'active': s.id === sendId}">
                     <div class="icon" aria-hidden="true">
                         <i class="fa fa-fw fa-lg" [ngClass]="s.type == 0 ? 'fa-file-o' : 'fa-file-text-o'"></i>
                     </div>
@@ -68,7 +68,7 @@
         </div>
     </div>
     <app-send-add-edit id="addEdit" class="details" *ngIf="action == 'add' || action == 'edit'" [sendId]="sendId" [type]="selectedSendType" 
-        (onSavedSend)="refresh()" (onCancelled)="cancel()"></app-send-add-edit>
+        (onSavedSend)="savedSend($event)" (onCancelled)="cancel($event)" (onDeletedSend)="deletedSend($event)"></app-send-add-edit>
     <div class="logo" *ngIf="!action">
         <div class="content">
             <div class="inner-content">

--- a/src/app/send/send.component.ts
+++ b/src/app/send/send.component.ts
@@ -98,7 +98,6 @@ export class SendComponent extends BaseSendComponent implements OnInit, OnDestro
     }
 
     async savedSend(s: SendView) {
-        console.log(s);
         await this.refresh();
         this.selectSend(s.id);
     }

--- a/src/app/send/send.component.ts
+++ b/src/app/send/send.component.ts
@@ -91,8 +91,20 @@ export class SendComponent extends BaseSendComponent implements OnInit, OnDestro
         this.sendId = null;
     }
 
+    async deletedSend(s: SendView) {
+        await this.refresh();
+        this.action = Action.None;
+        this.sendId = null;
+    }
+
+    async savedSend(s: SendView) {
+        console.log(s);
+        await this.refresh();
+        this.selectSend(s.id);
+    }
+
     async selectSend(sendId: string) {
-        if (sendId === this.sendId) {
+        if (sendId === this.sendId && this.action === Action.Edit) {
             return;
         }
         this.action = Action.Edit;

--- a/src/app/send/send.component.ts
+++ b/src/app/send/send.component.ts
@@ -56,11 +56,6 @@ export class SendComponent extends BaseSendComponent implements OnInit, OnDestro
             this.ngZone.run(async () => {
                 switch (message.command) {
                     case 'syncCompleted':
-                        if (message.successfully) {
-                            await this.load();
-                        }
-                        break;
-                    case 'syncCompleted':
                         await this.load();
                         break;
                 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1583,5 +1583,38 @@
   },
   "newPassword": {
     "message": "New Password"
+  },
+  "whatTypeOfSend": {
+    "message": "What type of Send is this?",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "createSend": {
+    "message": "Create Send",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
+  },
+  "sendTextDesc": {
+    "message": "The text you want to send."
+  },
+  "sendFileDesc": {
+    "message": "The file you want to send."
+  },
+  "days": {
+    "message": "$DAYS$ days",
+    "placeholders": {
+      "days": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "oneDay": {
+    "message": "1 day"
+  },
+  "custom": {
+    "message": "Custom"
+  },
+  "deleteSendConfirmation": {
+    "message": "Are you sure you want to delete this Send?",
+    "description": "'Send' is a noun and the name of a feature called 'Bitwarden Send'. It should not be translated."
   }
 }

--- a/src/scss/box.scss
+++ b/src/scss/box.scss
@@ -102,7 +102,7 @@
     &:hover, &:focus, &.active {
         @include themify($themes) {
             background-color: themed('boxBackgroundHoverColor');
-            textarea {
+            > * {
                 background-color: themed('boxBackgroundHoverColor');
             }
         }
@@ -169,7 +169,7 @@
     &.box-content-row-multi {
         width: 100%;
 
-        input:not([type="checkbox"]):not([type="checkbox"]) {
+        input:not([type="checkbox"]):not([type="radio"]) {
             width: 100%;
         }
 
@@ -251,8 +251,8 @@
     }
 
     &.box-content-row-radio {
-       display: grid; 
-       grid-template-columns: 1fr;
+       display: flex; 
+       flex-direction: column;
        .item {
            display: flex;
            flex: 1;

--- a/src/scss/box.scss
+++ b/src/scss/box.scss
@@ -102,7 +102,7 @@
     &:hover, &:focus, &.active {
         @include themify($themes) {
             background-color: themed('boxBackgroundHoverColor');
-            > * {
+            textarea {
                 background-color: themed('boxBackgroundHoverColor');
             }
         }
@@ -118,7 +118,7 @@
         overflow-x: auto;
     }
 
-    .row-label, label {
+    .row-label, label:not(.label-hack) {
         font-size: $font-size-small;
         display: block;
         width: 100%;
@@ -169,7 +169,7 @@
     &.box-content-row-multi {
         width: 100%;
 
-        input:not([type="checkbox"]) {
+        input:not([type="checkbox"]):not([type="checkbox"]) {
             width: 100%;
         }
 
@@ -250,7 +250,22 @@
         }
     }
 
-    input:not([type="checkbox"]), textarea {
+    &.box-content-row-radio {
+       display: grid; 
+       grid-template-columns: 1fr;
+       .item {
+           display: flex;
+           flex: 1;
+           align-items: center;
+
+           > .radio {
+                margin-right: 5px;
+                margin-top: 0;
+           }
+       }
+    }
+
+    input:not([type="checkbox"]):not([type="radio"]), textarea {
         border: none;
         width: 100%;
         background-color: transparent;


### PR DESCRIPTION
## Objective
> Create a functional and good UI for Bitwarden Send on desktop

## Code Changes
### jslib
- update to latest

### add-edit.component
- Cleared `password` on refresh since we don't ever show that value after creation
- Removed the `<ng-container>` wrapping the form and moved its `*ngIf` to the form's `.inner-content` so the page layout doesn't flicker in and out of existence when changing operations. 
- Added support for creating Sends within the form (create specific inputs, etc.).
- Added support for a cancel button that clears the form & sets its action to `None`. This works the same way the Vault cancel button does.

**NOTE:** The File/Text switcher is a radio button. Mobile & (I think) browser are using a bootstrap toggle switcher. Because `web` currently is not using a toggle, and bootstrap isn't used on desktop, desktop is currently using radio buttons.

### send.component
- Added `onCancel`, `onSaveSend` and `onDeletedSend` output handlers to refresh the screen with relevant data from those actions.
- Added sync support. This was in jslib, but was removed for client specific logic elsewhere. The implementation here is exactly as it was previously in jslib.
- Returned from `selectSend()` if the clicked Send is already selected to prevent the screen from trying to refresh unnecessarily. 

### messages.json
- Added more strings, all of which existed already in the web client.

### box.scss
- Added an exception to the default `.box label` styling because it does not work with radio buttons. This should probably get a genuine refactor at some point, but the changes required seemed out of scope for the Send implementation.
- Added `radio` type exceptions to any rules that already had `checkbox` type exceptions
- Added radio button stylings in the form of `.box-content-row-radio`, similar to how other input type rows get styled.

## Testing Considerations
### Completed Functionality:
- Navigating between My Vault and Send
- Viewing the list of Sends
- Filtering Sends by type
- Searching for Sends
- Viewing a Send's details
- Creating a new Send
- Editing an existing Send
- Deleting a Send
- Live sync
- Cancelling an add/edit action

### Features Not Ready For Testing
- Using menu bar functions (password generator, password history etc.) from the Send tab.
- Right-click menu for Sends similar to what is present in Ciphers
- Status badges in the Send list (disabled, password protected, etc.)
- A share button
- Recent design requirements changes (hiding optional fields by default, copy link on save option, show password).
- Blocking File sends behind a premium subscription
- Disabled Send policy implementation

## Demo
https://user-images.githubusercontent.com/15897251/108104274-187a4a80-7059-11eb-8596-8faac64383a3.mov