### PR TITLE
Add extra encrypted export warnings

### DIFF
--- a/src/app/vault/export.component.ts
+++ b/src/app/vault/export.component.ts
@@ -5,6 +5,8 @@ import {
     OnInit,
 } from '@angular/core';
 
+import * as os from 'os';
+
 import { CryptoService } from 'jslib/abstractions/crypto.service';
 import { EventService } from 'jslib/abstractions/event.service';
 import { ExportService } from 'jslib/abstractions/export.service';
@@ -48,5 +50,22 @@ export class ExportComponent extends BaseExportComponent implements OnInit {
 
     onWindowHidden() {
         this.showPassword = false;
+    }
+
+    async warningDialog() {
+        if (this.encryptedFormat) {
+            return await this.platformUtilsService.showDialog(
+                this.i18nService.t('encExportKeyWarningDesc') +
+                os.EOL + os.EOL +
+                this.i18nService.t('encExportAccountWarningDesc'),
+                this.i18nService.t('confirmVaultExport'), this.i18nService.t('exportVault'),
+                this.i18nService.t('cancel'), 'warning',
+                true);
+        } else {
+            return await this.platformUtilsService.showDialog(
+                this.i18nService.t('exportWarningDesc'),
+                this.i18nService.t('confirmVaultExport'), this.i18nService.t('exportVault'),
+                this.i18nService.t('cancel'), 'warning');
+        }
     }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1227,8 +1227,11 @@
   "exportWarningDesc": {
     "message": "This export contains your vault data in an unencrypted format. You should not store or send the exported file over unsecure channels (such as email). Delete it immediately after you are done using it."
   },
-  "encExportWarningDesc": {
+  "encExportKeyWarningDesc": {
     "message": "This export encrypts your data using your account's encryption key. If you ever rotate your account's encryption key you should export again since you will not be able to decrypt this export file."
+  },
+  "encExportAccountWarningDesc": {
+    "message": "Account encryption keys are unique to each Bitwarden user account, so you can't import an encrypted export into a different account."
   },
   "exportMasterPassword": {
     "message": "Enter your master password to export your vault data."


### PR DESCRIPTION
## Objective
Companion to https://github.com/bitwarden/web/pull/866

## Code changes
This relies on https://github.com/bitwarden/jslib/pull/295. It overrides the `warningDialog()` method so we can use EOL chars instead of `<p>` tags in the warning dialog.

## Screenshots
![Screen Shot 2021-03-05 at 7 52 06 am](https://user-images.githubusercontent.com/31796059/110039264-b32e9500-7d8c-11eb-9e8a-a2fada17c4d4.png)
