### PR TITLE
fixed icon redirect bug on Sends

### DIFF
--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -177,8 +177,7 @@
                 <i class="fa fa-copy fa-lg fa-fw" aria-hidden="true"></i>
             </button>
             <button #deleteBtn appBlurClick type="button" (click)="delete()" class="danger"
-                appA11yTitle="{{'delete' | i18n}}" *ngIf="editMode" [disabled]="deleteBtn.loading"
-                [appApiAction]="deletePromise">
+                appA11yTitle="{{'delete' | i18n}}" *ngIf="editMode">
                 <i class="fa fa-trash-o fa-lg fa-fw" [hidden]="deleteBtn.loading" aria-hidden="true"></i>
                 <i class="fa fa-spinner fa-spin fa-lg fa-fw" [hidden]="!deleteBtn.loading" aria-hidden="true"></i>
             </button>

--- a/src/app/send/send.component.html
+++ b/src/app/send/send.component.html
@@ -42,7 +42,7 @@
             <div class="list" *ngIf="filteredSends.length" infiniteScroll [infiniteScrollDistance]="1"
                 [infiniteScrollContainer]="'#items .content'" [fromRoot]="true" (scrolled)="loadMore()">
                 <a *ngFor="let s of filteredSends" appStopClick (click)="selectSend(s.id)"
-                    href="#" title="{{'viewItem' | i18n}}" (contextmenu)="viewSendMenu(s)"
+                    title="{{'viewItem' | i18n}}" (contextmenu)="viewSendMenu(s)"
                     [ngClass]="{'active': s.id === sendId}" class="flex-list-item">
                     <div class="item-icon" aria-hidden="true">
                         <i class="fa fa-fw fa-lg" [ngClass]="s.type == 0 ? 'fa-file-o' : 'fa-file-text-o'"></i>


### PR DESCRIPTION
Resolves https://app.asana.com/0/1199659118818122/1200021393754089/f

1. Removed the href tag from Send items. The redirect doesn't fire when clicking the parent <a> tag, but clicking the icons was still picking up the href. It is not needed anyway, as no redirect should be happening here.


Also resolves https://bitwarden.slack.com/archives/GRN5AAZ6Y/p1614913418261400
1. Removed the disabled tag from Send delete buttons on the page. There is no real loading element here, the button is destroyed as soon as the confirmation is sent.