### PR TITLE
added file size to Send view

### DIFF
--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -40,7 +40,7 @@
                     <ng-container *ngIf="editMode && send.type === sendType.File">
                         <div class="box-content-row" appBoxRow>
                             <label for="file">{{'file' | i18n}}</label>
-                            <input id="file" type="text" name="file" [(ngModel)]="send.file.fileName" readonly [disabled]="disableSend">
+                            <div class="row-main">{{send.file.fileName}} ({{send.file.sizeName}})</div>
                         </div>
                     </ng-container>
                     <ng-container *ngIf="send.type === sendType.Text">


### PR DESCRIPTION
File sends are missing the file size indicator on desktop. This PR adds it, and uses element styles more consistent with `browser`.
![Screen Shot 2021-03-09 at 2 32 36 PM](https://user-images.githubusercontent.com/15897251/110526864-4f85ce00-80e4-11eb-8f64-e07ed5d1ab23.png)
