### PR TITLE
Add script for downloading legacy safari extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ yarn-error.log
 *.provisionprofile
 *.env
 PlugIns/safari.appex/
+PlugIns/safari-legacy.appex/

--- a/scripts/download-legacy-safari.ps1
+++ b/scripts/download-legacy-safari.ps1
@@ -1,10 +1,12 @@
 $dir = Split-Path -Parent $MyInvocation.MyCommand.Path;
 $rootDir = $dir + "\..";
 $outputPath = $rootDir + "\PlugIns";
-$downloadOutput = $outputPath + "\safari-legacy.appex.zip"
+$zipFileName = "safari-legacy.appex.zip";
+$downloadOutput = $outputPath + "\" + $zipFileName;
 
 Invoke-WebRequest -Uri "https://github.com/bitwarden/browser/releases/download/v1.48.1/safari-legacy.appex.zip" -OutFile $downloadOutput
 
-Expand-Archive -Path $downloadOutput -DestinationPath $outputPath
+Set-Location $outputPath
+Invoke-Expression -Command "unzip $zipFileName"
 
 Remove-Item $downloadOutput

--- a/scripts/download-legacy-safari.ps1
+++ b/scripts/download-legacy-safari.ps1
@@ -1,0 +1,10 @@
+$dir = Split-Path -Parent $MyInvocation.MyCommand.Path;
+$rootDir = $dir + "\..";
+$pluginsAppex = $rootDir + "\PlugIns\safari-legacy.appex";
+$downloadOutput = $pluginsAppex + ".zip"
+
+Invoke-WebRequest -Uri "https://github.com/bitwarden/browser/releases/download/v1.48.1/safari-legacy.appex.zip" -OutFile $downloadOutput
+
+Expand-Archive -Path $downloadOutput -DestinationPath $pluginsAppex
+
+Remove-Item $downloadOutput

--- a/scripts/download-legacy-safari.ps1
+++ b/scripts/download-legacy-safari.ps1
@@ -1,10 +1,10 @@
 $dir = Split-Path -Parent $MyInvocation.MyCommand.Path;
 $rootDir = $dir + "\..";
-$pluginsAppex = $rootDir + "\PlugIns\safari-legacy.appex";
-$downloadOutput = $pluginsAppex + ".zip"
+$outputPath = $rootDir + "\PlugIns";
+$downloadOutput = $outputPath + "\safari-legacy.appex.zip"
 
 Invoke-WebRequest -Uri "https://github.com/bitwarden/browser/releases/download/v1.48.1/safari-legacy.appex.zip" -OutFile $downloadOutput
 
-Expand-Archive -Path $downloadOutput -DestinationPath $pluginsAppex
+Expand-Archive -Path $downloadOutput -DestinationPath $outputPath
 
 Remove-Item $downloadOutput


### PR DESCRIPTION
## Overview
To provide better comparability with pre Safari 14, and on M1 MacBooks, we should include the old extension during a transition period.