### PR TITLE
Write native messaging manifests for Chrome/edge beta/dev/canary

### DIFF
--- a/resources/entitlements.mas.plist
+++ b/resources/entitlements.mas.plist
@@ -12,7 +12,13 @@
 	<array>
 		<string>/Library/Application Support/Mozilla/NativeMessagingHosts/</string>
 		<string>/Library/Application Support/Google/Chrome/NativeMessagingHosts/</string>
+		<string>/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts/</string>
+		<string>/Library/Application Support/Google/Chrome Dev/NativeMessagingHosts/</string>
+		<string>/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts/</string>
 		<string>/Library/Application Support/Microsoft Edge/NativeMessagingHosts/</string>
+		<string>/Library/Application Support/Microsoft Edge Beta/NativeMessagingHosts/</string>
+		<string>/Library/Application Support/Microsoft Edge Dev/NativeMessagingHosts/</string>
+		<string>/Library/Application Support/Microsoft Edge Canary/NativeMessagingHosts/</string>
         <string>/Library/Application Support/Vivaldi/NativeMessagingHosts/</string>
 	</array>
 </dict>

--- a/src/main/nativeMessaging.main.ts
+++ b/src/main/nativeMessaging.main.ts
@@ -161,7 +161,13 @@ export class NativeMessagingMain {
         return {
             'Firefox': `${this.homedir()}/Library/Application\ Support/Mozilla/NativeMessagingHosts/`,
             'Chrome': `${this.homedir()}/Library/Application\ Support/Google/Chrome/NativeMessagingHosts/`,
+            'Chrome Beta': `${this.homedir()}/Library/Application\ Support/Google/Chrome\ Beta/NativeMessagingHosts/`,
+            'Chrome Dev': `${this.homedir()}/Library/Application\ Support/Google/Chrome\ Dev/NativeMessagingHosts/`,
+            'Chrome Canary': `${this.homedir()}/Library/Application\ Support/Google/Chrome\ Canary/NativeMessagingHosts/`,
             'Microsoft Edge': `${this.homedir()}/Library/Application\ Support/Microsoft\ Edge/NativeMessagingHosts/`,
+            'Microsoft Edge Beta': `${this.homedir()}/Library/Application\ Support/Microsoft\ Edge\ Beta/NativeMessagingHosts/`,
+            'Microsoft Edge Dev': `${this.homedir()}/Library/Application\ Support/Microsoft\ Edge\ Dev/NativeMessagingHosts/`,
+            'Microsoft Edge Canary': `${this.homedir()}/Library/Application\ Support/Microsoft\ Edge\ Canary/NativeMessagingHosts/`,
             'Vivaldi': `${this.homedir()}/Library/Application\ Support/Vivaldi/NativeMessagingHosts/`,
         };
     }


### PR DESCRIPTION
## Overview
Beta, dev and canary of Chrome and Microsoft Edge uses different directories for the native messaging manifests. To avoid future troubleshooting for users we might as well write the manifests in those directories.

Resolves https://github.com/bitwarden/desktop/issues/797