### PR TITLE
Temporary fix for masdev

### DIFF
--- a/patches/app-builder-lib+22.10.5.patch
+++ b/patches/app-builder-lib+22.10.5.patch
@@ -1,5 +1,13 @@
+diff --git a/node_modules/app-builder-lib/.DS_Store b/node_modules/app-builder-lib/.DS_Store
+new file mode 100644
+index 0000000..ce3f896
+Binary files /dev/null and b/node_modules/app-builder-lib/.DS_Store differ
+diff --git a/node_modules/app-builder-lib/out/.DS_Store b/node_modules/app-builder-lib/out/.DS_Store
+new file mode 100644
+index 0000000..405c52a
+Binary files /dev/null and b/node_modules/app-builder-lib/out/.DS_Store differ
 diff --git a/node_modules/app-builder-lib/out/macPackager.js b/node_modules/app-builder-lib/out/macPackager.js
-index 41e067c..1aec3a6 100644
+index 41e067c..cd97293 100644
 --- a/node_modules/app-builder-lib/out/macPackager.js
 +++ b/node_modules/app-builder-lib/out/macPackager.js
 @@ -292,6 +292,23 @@ class MacPackager extends _platformPackager().PlatformPackager {
@@ -43,3 +51,12 @@ index 41e067c..1aec3a6 100644
            await rmdir(x64AppOutDir, {
              recursive: true
            });
+@@ -611,7 +636,7 @@ exports.default = MacPackager;
+ 
+ function getCertificateType(isMas, isDevelopment) {
+   if (isDevelopment) {
+-    return "Mac Developer";
++    return "Apple Development";
+   }
+ 
+   return isMas ? "3rd Party Mac Developer Application" : "Developer ID Application";

--- a/patches/app-builder-lib+22.10.5.patch
+++ b/patches/app-builder-lib+22.10.5.patch
@@ -1,11 +1,3 @@
-diff --git a/node_modules/app-builder-lib/.DS_Store b/node_modules/app-builder-lib/.DS_Store
-new file mode 100644
-index 0000000..ce3f896
-Binary files /dev/null and b/node_modules/app-builder-lib/.DS_Store differ
-diff --git a/node_modules/app-builder-lib/out/.DS_Store b/node_modules/app-builder-lib/out/.DS_Store
-new file mode 100644
-index 0000000..405c52a
-Binary files /dev/null and b/node_modules/app-builder-lib/out/.DS_Store differ
 diff --git a/node_modules/app-builder-lib/out/macPackager.js b/node_modules/app-builder-lib/out/macPackager.js
 index 41e067c..cd97293 100644
 --- a/node_modules/app-builder-lib/out/macPackager.js


### PR DESCRIPTION
## Overview
I was unable to build masdev correctly due to apple changing from `Mac Developer` to `Apple Development`. This temporarily resolves the issue until electron-builder can be fixed.