### PR TITLE
Simplify logic for resolving path to exe for native messaging

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,7 @@ export class Main {
             this.biometricMain = new BiometricDarwinMain(this.storageService, this.i18nService);
         }
 
-        this.nativeMessagingMain = new NativeMessagingMain(this.logService, this.windowMain, app.getPath('userData'), app.getAppPath());
+        this.nativeMessagingMain = new NativeMessagingMain(this.logService, this.windowMain, app.getPath('userData'), app.getPath('exe'));
     }
 
     bootstrap() {

--- a/src/main/nativeMessaging.main.ts
+++ b/src/main/nativeMessaging.main.ts
@@ -12,7 +12,7 @@ export class NativeMessagingMain {
     private connected = false;
     private socket: any;
 
-    constructor(private logService: LogService, private windowMain: WindowMain, private userPath: string, private appPath: string) {}
+    constructor(private logService: LogService, private windowMain: WindowMain, private userPath: string, private exePath: string) {}
 
     async listen() {
         ipc.config.id = 'bitwarden';
@@ -182,14 +182,11 @@ export class NativeMessagingMain {
     }
 
     private binaryPath() {
-        const dir = path.join(this.appPath, '..');
         if (process.platform === 'win32') {
-            return path.join(dir, 'native-messaging.bat');
-        } else if (process.platform === 'darwin') {
-            return '/Applications/Bitwarden.app/Contents/MacOS/Bitwarden';
+            return path.join(path.basename(this.exePath), 'resources', 'native-messaging.bat');
         }
 
-        return path.join(dir, '..', 'bitwarden');
+        return this.exePath;
     }
 
     private async createWindowsRegistry(check: string, location: string, jsonFile: string) {


### PR DESCRIPTION
## Overview
Our hardcoded path on Mac makes it difficult to QA test Native messaging now that masdev works. This PR changes it to use `app.GetPath('exe')`. I've tested it in in devtools on our current Mac App Store release and it returns the expected path.

### Testing Considerations
We need to do regression testing on Mac and Windows (linux doesn't support browser biometrics yet) to ensure nothing broke by changing the path.
