### PR TITLE
Distribute mac arm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,3 +369,8 @@ jobs:
           asset_name: Bitwarden-${{ env.PACKAGE_VERSION }}.pkg
           asset_path: ./dist/mas/Bitwarden-${{ env.PACKAGE_VERSION }}.pkg
           asset_content_type: application
+
+      - name: Build ARM application
+        run: npm run dist:mac:arm64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "dist:win": "npm run build && npm run pack:win",
     "dist:win:ci": "npm run build && npm run pack:win:ci",
     "publish:lin": "npm run build && npm run clean:dist && electron-builder --linux --x64 -p always",
-    "publish:mac": "npm run build && npm run clean:dist && electron-builder --mac -p always",
+    "publish:mac": "npm run build && npm run clean:dist && electron-builder --mac --universal -p always",
     "publish:mac:mas": "npm run dist:mac:mas && npm run upload:mas",
     "publish:win": "npm run build && npm run clean:dist && electron-builder --win --x64 --arm64 --ia32 -p always -c.win.certificateSubjectName=\"8bit Solutions LLC\"",
     "upload:mas": "xcrun altool --upload-app --type osx --file \"$(find ./dist/mas/Bitwarden*.pkg)\" --username $APPLE_ID_USERNAME --password $APPLE_ID_PASSWORD"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "dist:dir": "npm run build && npm run pack:dir",
     "dist:lin": "npm run build && npm run pack:lin",
     "dist:mac": "npm run build && npm run pack:mac",
+    "dist:mac:arm64": "npm run build && npm run pack:mac:arm64",
     "dist:mac:mas": "npm run build && npm run pack:mac:mas",
     "dist:mac:masdev": "npm run build && npm run pack:mac:masdev",
     "dist:win": "npm run build && npm run pack:win",


### PR DESCRIPTION
Original PR https://github.com/bitwarden/desktop/pull/793 and ticket https://github.com/bitwarden/desktop/issues/792

In the original PR, I added `--universal` to `pack:mac:mas` and `pack:mac:masdev` and added target `pack:mac:arm64` but I forgot to publish these binaries.

After looking at the windows arm pr https://github.com/bitwarden/desktop/pull/667, it looks like updating the `release.yml` and maybe the `build.yml` github actions ?

Would appreciate help on this if time permits.

cc: @Hinton @cscharf 