### PR TITLE
Fix Premium Required message after sso auth

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -208,6 +208,7 @@ export class AppComponent implements OnInit {
                         break;
                     case 'ssoCallback':
                         this.router.navigate(['sso'], { queryParams: { code: message.code, state: message.state } });
+                        break;
                     case 'premiumRequired':
                         const premiumConfirmed = await this.platformUtilsService.showDialog(
                             this.i18nService.t('premiumRequiredDesc'), this.i18nService.t('premiumRequired'),


### PR DESCRIPTION
## Objective
Users were getting a "Premium required" error message when trying to login via SSO, even though they were members of a paid organization.

## Code changes
Put in a happy little `break` statement. The `ssoCallback` case was flowing into the `premiumRequired` case, which happened to be immediately after.