### PR TITLE
Don't use tokenService to manage emailVerified

### DIFF
--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -21,7 +21,7 @@ export class AddEditComponent extends BaseAddEditComponent {
     constructor(i18nService: I18nService, platformUtilsService: PlatformUtilsService,
         environmentService: EnvironmentService, datePipe: DatePipe,
         sendService: SendService, userService: UserService,
-        messagingService: MessagingService, policyService: PolicyService, tokenService: TokenService) {
+        messagingService: MessagingService, policyService: PolicyService) {
         super(i18nService, platformUtilsService, environmentService,
               datePipe, sendService, userService, messagingService, policyService);
     }

--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -8,7 +8,6 @@ import { MessagingService } from 'jslib/abstractions/messaging.service';
 import { PlatformUtilsService } from 'jslib/abstractions/platformUtils.service';
 import { PolicyService } from 'jslib/abstractions/policy.service';
 import { SendService } from 'jslib/abstractions/send.service';
-import { TokenService } from 'jslib/abstractions/token.service';
 import { UserService } from 'jslib/abstractions/user.service';
 
 import { AddEditComponent as BaseAddEditComponent } from 'jslib/angular/components/send/add-edit.component';

--- a/src/app/send/add-edit.component.ts
+++ b/src/app/send/add-edit.component.ts
@@ -23,7 +23,7 @@ export class AddEditComponent extends BaseAddEditComponent {
         sendService: SendService, userService: UserService,
         messagingService: MessagingService, policyService: PolicyService, tokenService: TokenService) {
         super(i18nService, platformUtilsService, environmentService,
-              datePipe, sendService, userService, messagingService, policyService, tokenService);
+              datePipe, sendService, userService, messagingService, policyService);
     }
 
     async refresh() {


### PR DESCRIPTION
## Objective

Bump jslib and remove `tokenService` from the send `add-edit` component. Required for https://github.com/bitwarden/jslib/pull/344.