### PR TITLE
Add custom-pipe to correct an issue with display of Unicode/Emoji passwords #768

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,9 +43,11 @@ import { StopClickDirective } from 'jslib/angular/directives/stop-click.directiv
 import { StopPropDirective } from 'jslib/angular/directives/stop-prop.directive';
 import { TrueFalseValueDirective } from 'jslib/angular/directives/true-false-value.directive';
 
-import { ColorPasswordPipeWithEmoji } from '../custom-pipes/color-password-with-emoji';
 import { I18nPipe } from 'jslib/angular/pipes/i18n.pipe';
 import { SearchCiphersPipe } from 'jslib/angular/pipes/search-ciphers.pipe';
+
+// custom-pipes
+import { ColorPasswordPipeWithEmoji } from '../custom-pipes/color-password-with-emoji';
 
 import { AddEditComponent } from './vault/add-edit.component';
 import { AttachmentsComponent } from './vault/attachments.component';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -43,7 +43,7 @@ import { StopClickDirective } from 'jslib/angular/directives/stop-click.directiv
 import { StopPropDirective } from 'jslib/angular/directives/stop-prop.directive';
 import { TrueFalseValueDirective } from 'jslib/angular/directives/true-false-value.directive';
 
-import { ColorPasswordPipe } from 'jslib/angular/pipes/color-password.pipe';
+import { ColorPasswordPipeWithEmoji } from '../custom-pipes/color-password-with-emoji';
 import { I18nPipe } from 'jslib/angular/pipes/i18n.pipe';
 import { SearchCiphersPipe } from 'jslib/angular/pipes/search-ciphers.pipe';
 
@@ -164,7 +164,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         CalloutComponent,
         CiphersComponent,
         CollectionsComponent,
-        ColorPasswordPipe,
+        ColorPasswordPipeWithEmoji,
         EnvironmentComponent,
         ExportComponent,
         FallbackSrcDirective,

--- a/src/app/vault/password-generator-history.component.html
+++ b/src/app/vault/password-generator-history.component.html
@@ -10,7 +10,7 @@
                         <div class="box-content-row box-content-row-flex" *ngFor="let h of history">
                             <div class="row-main">
                                 <div class="password-wrapper monospaced" appSelectCopy
-                                    [innerHTML]="h.password | colorPassword"></div>
+                                    [innerHTML]="h.password | colorPasswordWithEmoji"></div>
                                 <span class="detail">{{h.date | date:'medium'}}</span>
                             </div>
                             <div class="action-buttons">

--- a/src/app/vault/password-generator.component.html
+++ b/src/app/vault/password-generator.component.html
@@ -6,7 +6,7 @@
                     {{'passwordGeneratorPolicyInEffect' | i18n}}
                 </app-callout>
                 <div class="password-block">
-                    <div class="password-wrapper" [innerHTML]="password | colorPassword" appSelectCopy></div>
+                    <div class="password-wrapper" [innerHTML]="password | colorPasswordWithEmoji" appSelectCopy></div>
                 </div>
                 <div class="box">
                     <div class="box-content condensed">

--- a/src/app/vault/view.component.html
+++ b/src/app/vault/view.component.html
@@ -31,7 +31,7 @@
                             <div [hidden]="showPassword" class="monospaced">
                                 {{cipher.login.maskedPassword}}</div>
                             <div [hidden]="!showPassword" class="monospaced password-wrapper" appSelectCopy
-                                [innerHTML]="cipher.login.password | colorPassword"></div>
+                                [innerHTML]="cipher.login.password | colorPasswordWithEmoji"></div>
                         </div>
                         <div class="action-buttons" *ngIf=cipher.viewPassword>
                             <button type="button" #checkPasswordBtn class="row-btn btn" appBlurClick

--- a/src/custom-pipes/color-password-with-emoji.ts
+++ b/src/custom-pipes/color-password-with-emoji.ts
@@ -1,0 +1,53 @@
+import {
+  Pipe,
+  PipeTransform,
+} from '@angular/core';
+
+/**
+* A pipe that sanitizes HTML and highlights numbers and special characters (in different colors each).
+*/
+@Pipe({ name: 'colorPasswordWithEmoji' })
+export class ColorPasswordPipeWithEmoji implements PipeTransform {
+  transform(password: string) {
+      // Regex Unicode property escapes for checking if emoji in passwords.
+      const regexpEmojiPresentation = /\p{Emoji_Presentation}/gu;
+      // Convert to an array to handle cases that stings have special characters, ie: emoji.
+      const passwordArray = Array.from(password);
+      let colorizedPassword = '';
+      for (let i = 0; i < passwordArray.length; i++) {
+          let character = passwordArray[i];
+          let isSpecial = false;
+          // Sanitize HTML first.
+          switch (character) {
+              case '&':
+                  character = '&amp;';
+                  isSpecial = true;
+                  break;
+              case '<':
+                  character = '&lt;';
+                  isSpecial = true;
+                  break;
+              case '>':
+                  character = '&gt;';
+                  isSpecial = true;
+                  break;
+              case ' ':
+                  character = '&nbsp;';
+                  isSpecial = true;
+                  break;
+              default:
+                  break;
+          }
+          let type = 'letter';
+          if (character.match(regexpEmojiPresentation)) {
+              type = 'emoji';
+          } else if (isSpecial || character.match(/[^\w ]/)) {
+              type = 'special';
+          } else if (character.match(/\d/)) {
+              type = 'number';
+          }
+          colorizedPassword += '<span class="password-' + type + '">' + character + '</span>';
+      }
+      return colorizedPassword;
+  }
+}

--- a/src/custom-pipes/color-password-with-emoji.ts
+++ b/src/custom-pipes/color-password-with-emoji.ts
@@ -3,8 +3,9 @@ import {
   PipeTransform,
 } from '@angular/core';
 
-/**
-* A pipe that sanitizes HTML and highlights numbers and special characters (in different colors each).
+/*
+ An updated pipe that sanitizes HTML, highlights numbers and special characters (in different colors each)
+ and handles Unicode / Emoji characters correctly.
 */
 @Pipe({ name: 'colorPasswordWithEmoji' })
 export class ColorPasswordPipeWithEmoji implements PipeTransform {


### PR DESCRIPTION
Hi, I've looked into issue #768 and the problem is associated with an angular pipe `ColorPasswordPipe` used for sanitizing HTML and colorizing the password. Unicode characters do not play well with this Pipe because of issues with Unicode, ie: `"💩".length === 2`, and how it parsed through a basic string. I've resolved the issue by creating a custom-pipe that can check for Unicode / Emoji characters. Unicode is an interesting rabbit hole to go down 😃 

Just because I can does not mean I should, please let me know if I should not have gone this route, one custom pipe problem is now we have to maintain it. I've admittedly had a hard time trying to find the source of the original `ColorPasswordPipe` but I figured I could submit this and start a discussion. The benefit to allowing Emoji in passwords (so Bitwarden supporting the correct view of them) is that they do create more complex passwords for users.

I set the new custom pipe `ColorPasswordPipeWithEmoji` to replace the Angular Pipe mentioned above in all locations being used.

The new pipe is simply an updated version of the Angular Pipe here: [ColorPasswordPipe](https://gist.github.com/gryffs/d171c8e6ad07ef5c1ce73a2566d2dbff)
