### PR TITLE
feature: configurable global shortcuts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "jslib"]
 	path = jslib
-	url = https://github.com/bitwarden/jslib.git
-	branch = master
+	url = https://github.com/SEAPUNK/bitwarden-jslib.git
+	branch = feature/configurable-global-shortcuts

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "sub:update": "git submodule update --remote",
     "sub:pull": "git submodule foreach git pull origin master",
     "sub:commit": "npm run sub:pull && git commit -am \"update submodule\"",
-    "postinstall": "./node_modules/.bin/electron-rebuild && npm run sub:init && patch-package",
+    "postinstall": "electron-rebuild && npm run sub:init && patch-package",
     "symlink:win": "rm -rf ./jslib && cmd /c mklink /J .\\jslib ..\\jslib",
     "symlink:mac": "npm run symlink:lin",
     "symlink:lin": "rm -rf ./jslib && ln -s ../jslib ./jslib",

--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -182,6 +182,16 @@
                             </select>
                             <small class="help-block">{{'languageDesc' | i18n}}</small>
                         </div>
+                        <div class="form-group">
+                            <div class="checkbox">
+                                <label for="enableGlobalShortcuts">
+                                    <input id="enableGlobalShortcuts" type="checkbox" name="EnableGlobalShortcuts"
+                                        [(ngModel)]="enableGlobalShortcuts" (change)="saveGlobalShortcuts()">
+                                    {{'enableGlobalShortcuts' | i18n}}
+                                </label>
+                            </div>
+                            <small class="help-block">{{'enableGlobalShortcutsDesc' | i18n}}</small>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -20,6 +20,7 @@ import { ConstantsService } from 'jslib/services/constants.service';
 
 import { ElectronConstants } from 'jslib/electron/electronConstants';
 
+import { GlobalShortcuts } from 'jslib/electron/services/electronGlobalShortcuts.service';
 import { isWindowsStore } from 'jslib/electron/utils';
 import { Utils } from 'jslib/misc/utils';
 
@@ -54,6 +55,8 @@ export class SettingsComponent implements OnInit {
     showAlwaysShowDock: boolean = false;
     openAtLogin: boolean;
     requireEnableTray: boolean = false;
+    globalShortcuts: GlobalShortcuts;
+    enableGlobalShortcuts: boolean;
 
     enableTrayText: string;
     enableTrayDescText: string;
@@ -165,6 +168,8 @@ export class SettingsComponent implements OnInit {
         this.alwaysShowDock = await this.storageService.get<boolean>(ElectronConstants.alwaysShowDock);
         this.showAlwaysShowDock = this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop;
         this.openAtLogin = await this.storageService.get<boolean>(ElectronConstants.openAtLogin);
+        this.globalShortcuts = await this.storageService.get<GlobalShortcuts>(ElectronConstants.globalShortcuts);
+        this.enableGlobalShortcuts = Array.from(Object.keys(this.globalShortcuts)).length !== 0;
     }
 
     async saveVaultTimeoutOptions() {
@@ -366,5 +371,13 @@ export class SettingsComponent implements OnInit {
 
     async saveBrowserIntegrationFingerprint() {
         await this.storageService.save(ElectronConstants.enableBrowserIntegrationFingerprint, this.enableBrowserIntegrationFingerprint);
+    }
+
+    async saveGlobalShortcuts() {
+        const globalShortcuts = {
+            [ElectronConstants.globalShortcutOpenWindow]: 'CommandOrControl+Shift+L',
+            [ElectronConstants.globalShortcutOpenPasswordGenerator]: 'CommandOrControl+Shift+G',
+        };
+        this.platformUtilsService.registerGlobalShortcuts(this.enableGlobalShortcuts ? globalShortcuts : {});
     }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -867,6 +867,12 @@
   "enableCloseToTrayDesc": {
     "message": "When closing the window, show an icon in the system tray instead."
   },
+  "enableGlobalShortcuts": {
+    "message": "Enable Global Shortcuts"
+  },
+  "enableGlobalShortcutsDesc": {
+    "message": "Enables keyboard shortcuts that can be used anywhere."
+  },
   "enableCloseToMenuBar": {
     "message": "Close to menu bar"
   },


### PR DESCRIPTION
This enables the ability to dynamically register arbitrary global
shortcuts. The UI is a placeholder, as I haven't implemented any way (in the UI) to
define your own keyboard shortcuts. Instead, the UI lets you
enable or disable predefined global shortcuts.

![2021-04-18_22-50-50](https://user-images.githubusercontent.com/4400726/115179333-bbbb0080-a098-11eb-86a6-ccf85aba44cd.png)

---

I'm not expecting this to be merged, but I figured I'd spend some time to get a feel for what the implementation would look like. I don't precisely know where to put everything, so I went with a best-guess approach.

Optimally, I envision the settings screen to show you a list of global shortcuts that you can click on, press a keyboard combination, and register that as shortcuts.

---

Let me know if you think this is worthwhile for me to pursue further.

Rel:
- https://github.com/bitwarden/desktop/pull/231
- https://github.com/bitwarden/desktop/pull/351
- https://github.com/bitwarden/desktop/issues/405
