### PR TITLE
Change unlock biometric button to be selectable using tab

### DIFF
--- a/src/app/accounts/lock.component.html
+++ b/src/app/accounts/lock.component.html
@@ -38,9 +38,9 @@
                 </button>
             </div>
             <div class="buttons-row" *ngIf="supportsBiometric && biometricLock">
-                <a class="btn block" appBlurClick (click)="unlockBiometric()">
+                <button class="btn block" appBlurClick (click)="unlockBiometric()">
                     {{biometricText | i18n}}
-                </a>
+                </button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Objective
The unlock with biometrics button is not selectable using tab. Which is caused by it being a `a` tag. Changing it to `button` resolves this issue, which is similar to the old in browser https://github.com/bitwarden/browser/pull/1578

Resolves #668 