### PR TITLE
Add unauthGuard and lockGuard to prevent unintended navigation

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,6 +5,8 @@ import {
 } from '@angular/router';
 
 import { AuthGuardService } from 'jslib/angular/services/auth-guard.service';
+import { lockGuardService } from 'jslib/angular/services/lock-guard.service';
+import { UnauthGuardService } from 'jslib/angular/services/unauth-guard.service';
 
 import { HintComponent } from './accounts/hint.component';
 import { LockComponent } from './accounts/lock.component';
@@ -20,8 +22,17 @@ import { VaultComponent } from './vault/vault.component';
 
 const routes: Routes = [
     { path: '', redirectTo: '/vault', pathMatch: 'full' },
-    { path: 'lock', component: LockComponent },
-    { path: 'login', component: LoginComponent },
+    {
+        path: 'lock',
+        component: LockComponent,
+        canActivate: [lockGuardService],
+    },
+    {
+        path: 'login',
+        component: LoginComponent,
+        canActivate: [UnauthGuardService],
+
+    },
     { path: '2fa', component: TwoFactorComponent },
     { path: 'register', component: RegisterComponent },
     {

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,7 +5,7 @@ import {
 } from '@angular/router';
 
 import { AuthGuardService } from 'jslib/angular/services/auth-guard.service';
-import { lockGuardService } from 'jslib/angular/services/lock-guard.service';
+import { LockGuardService } from 'jslib/angular/services/lock-guard.service';
 import { UnauthGuardService } from 'jslib/angular/services/unauth-guard.service';
 
 import { HintComponent } from './accounts/hint.component';
@@ -25,7 +25,7 @@ const routes: Routes = [
     {
         path: 'lock',
         component: LockComponent,
-        canActivate: [lockGuardService],
+        canActivate: [LockGuardService],
     },
     {
         path: 'login',

--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -19,6 +19,8 @@ import { I18nService } from '../services/i18n.service';
 import { NativeMessagingService } from '../services/nativeMessaging.service';
 
 import { AuthGuardService } from 'jslib/angular/services/auth-guard.service';
+import { UnauthGuardService } from 'jslib/angular/services/unauth-guard.service';
+import { lockGuardService } from 'jslib/angular/services/lock-guard.service';
 import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
 import { ValidationService } from 'jslib/angular/services/validation.service';
 
@@ -186,6 +188,8 @@ export function initFactory(): Function {
     providers: [
         ValidationService,
         AuthGuardService,
+        UnauthGuardService,
+        lockGuardService,
         { provide: AuditServiceAbstraction, useValue: auditService },
         { provide: AuthServiceAbstraction, useValue: authService },
         { provide: CipherServiceAbstraction, useValue: cipherService },

--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -19,9 +19,9 @@ import { I18nService } from '../services/i18n.service';
 import { NativeMessagingService } from '../services/nativeMessaging.service';
 
 import { AuthGuardService } from 'jslib/angular/services/auth-guard.service';
-import { UnauthGuardService } from 'jslib/angular/services/unauth-guard.service';
-import { lockGuardService } from 'jslib/angular/services/lock-guard.service';
 import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
+import { LockGuardService } from 'jslib/angular/services/lock-guard.service';
+import { UnauthGuardService } from 'jslib/angular/services/unauth-guard.service';
 import { ValidationService } from 'jslib/angular/services/validation.service';
 
 import { ApiService } from 'jslib/services/api.service';
@@ -189,7 +189,7 @@ export function initFactory(): Function {
         ValidationService,
         AuthGuardService,
         UnauthGuardService,
-        lockGuardService,
+        LockGuardService,
         { provide: AuditServiceAbstraction, useValue: auditService },
         { provide: AuthServiceAbstraction, useValue: authService },
         { provide: CipherServiceAbstraction, useValue: cipherService },


### PR DESCRIPTION
## Objective

Electron does not present the user with browser-style forward & back buttons, however the user can still use dedicated forward/back buttons on their mouse or keyboard. This allows the user to navigate back to the login or unlock pages, which makes them appear logged out/locked even though they aren't.

## Code changes

At first I looked at how to disable browser-style forward/back navigation in Electron. [This SO answer](https://stackoverflow.com/questions/66257921/how-to-disable-next-previous-key-from-mouse-in-electron) sums it up fairly well - there is no standardized way of doing this, Electron supposedly implements `browser-backward` and `browser-forward` events but they don't work (which I verified), the best you can do is intercept the mouse button presses (which does work but isn't a good solution). In fact, Linux and Mac users have the opposite problem, as [Electron's support for forward/back buttons is inconsistent across platforms](https://github.com/electron/electron/issues/6996).

To take another approach, the web vault has logic in the `lock.component.ts` constructor that checks if the vault is already unlocked, so I copied that. However, it caused the unlock screen to flash briefly as the component renders.

In the end I found `unauthGuardService` in web, lifted that up to jslib, and applied it to the `login` route. I then created a similar guard, `lockGuardService` (which requires the user's vault to be locked to allow navigation) and added that to the `lock` route. I have then refactored web to rely on these services in jslib rather than its own service + constructor logic.

This does not seem to be an issue in the browser client so I was going to leave it well enough alone, but I can implement the guards there as well for consistency's sake if required.

Other repos:
* jslib: https://github.com/bitwarden/jslib/pull/351
* web: https://github.com/bitwarden/web/pull/939

jslib needs to be merged first.