### PR TITLE
Implement the markAsDirty form controls for AddEditComponent(#761).

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -1,4 +1,4 @@
-<form #form (ngSubmit)="submit()" [appApiAction]="formPromise">
+<form #form="ngForm" (ngSubmit)="submit()" [appApiAction]="formPromise">
     <div class="content">
         <div class="inner-content" *ngIf="cipher">
             <div class="box">

--- a/src/app/vault/add-edit.component.ts
+++ b/src/app/vault/add-edit.component.ts
@@ -3,7 +3,9 @@ import {
     NgZone,
     OnChanges,
     OnDestroy,
+    ViewChild
 } from '@angular/core';
+import { NgForm } from '@angular/forms';
 
 import { AuditService } from 'jslib/abstractions/audit.service';
 import { CipherService } from 'jslib/abstractions/cipher.service';
@@ -21,6 +23,7 @@ import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
 
 import { AddEditComponent as BaseAddEditComponent } from 'jslib/angular/components/add-edit.component';
 
+
 const BroadcasterSubscriptionId = 'AddEditComponent';
 
 @Component({
@@ -28,6 +31,8 @@ const BroadcasterSubscriptionId = 'AddEditComponent';
     templateUrl: 'add-edit.component.html',
 })
 export class AddEditComponent extends BaseAddEditComponent implements OnChanges, OnDestroy {
+    @ViewChild('form')
+    private form: NgForm;
     constructor(cipherService: CipherService, folderService: FolderService,
         i18nService: I18nService, platformUtilsService: PlatformUtilsService,
         auditService: AuditService, stateService: StateService,
@@ -84,4 +89,8 @@ export class AddEditComponent extends BaseAddEditComponent implements OnChanges,
         return (!this.editMode || this.cloneMode) && this.ownershipOptions
             && (this.ownershipOptions.length > 1 || !this.allowPersonal);
     }
+
+    markPasswordAsDirty() {
+        this.form.controls['Login.Password'].markAsDirty();
+      }
 }

--- a/src/app/vault/add-edit.component.ts
+++ b/src/app/vault/add-edit.component.ts
@@ -92,5 +92,5 @@ export class AddEditComponent extends BaseAddEditComponent implements OnChanges,
 
     markPasswordAsDirty() {
         this.form.controls['Login.Password'].markAsDirty();
-      }
+    }
 }

--- a/src/app/vault/vault.component.ts
+++ b/src/app/vault/vault.component.ts
@@ -554,6 +554,7 @@ export class VaultComponent implements OnInit, OnDestroy {
             this.modal.close();
             if (this.addEditComponent != null && this.addEditComponent.cipher != null &&
                 this.addEditComponent.cipher.type === CipherType.Login && this.addEditComponent.cipher.login != null) {
+                this.addEditComponent.markPasswordAsDirty();
                 this.addEditComponent.cipher.login.password = password;
             }
         });


### PR DESCRIPTION
This PR should correct the issue reported in #761 

The issue was due to the fact the the password generator filled the new password but did not mark the input as dirty. So, if the input was still marked as pristine the prompt would not trigger. I added a custom method for marking the password input as dirty and called said method when the password is changed.

This issue also existed if the user attempted to add a new login and had not touched any field other than the password generator and this also corrects the functionality there. Please let me know what you think.