### PR TITLE
Don't submit form when unlocking with biometrics

### DIFF
--- a/src/app/accounts/lock.component.html
+++ b/src/app/accounts/lock.component.html
@@ -38,7 +38,7 @@
                 </button>
             </div>
             <div class="buttons-row" *ngIf="supportsBiometric && biometricLock">
-                <button class="btn block" appBlurClick (click)="unlockBiometric()">
+                <button type="button" class="btn block" appBlurClick (click)="unlockBiometric()">
                     {{biometricText | i18n}}
                 </button>
             </div>


### PR DESCRIPTION
## Objective

PR #846 changed the "Unlock with biometrics" button to use `<button>` instead of `<a>`. However, this has the effect of submitting the form when the button is pressed, which prompts a "Master Password is required" error toast after logging in.

This will need to be cherry-picked into `rc` once merged.

## Code changes

Add `type="button"`, which prevents the button from submitting the form.