### PR TITLE
Vertically align the name and icon in secured notes list.

### DIFF
--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -12,7 +12,7 @@
             (scrolled)="loadMore()">
             <a *ngFor="let c of filteredCiphers" appStopClick (click)="selectCipher(c)"
                 (contextmenu)="rightClickCipher(c)" href="#" title="{{'viewItem' | i18n}}"
-                [ngClass]="{'active': c.id === activeCipherId}">
+                [ngClass]="{'active': c.id === activeCipherId}" class="box-content-row box-content-row-flex">
                 <app-vault-icon [cipher]="c"></app-vault-icon>
                 <span class="text">
                     {{c.name}}


### PR DESCRIPTION
Hello, this PR is meant to correct the issue here: #599

The above issue was confirmed on mac as well.

I've aded the classes `box-content-row box-content-row-flex` in order to align the text with the image.