### PR TITLE
Write native messaging manifests for Chromium

### DIFF
--- a/resources/entitlements.mas.plist
+++ b/resources/entitlements.mas.plist
@@ -15,6 +15,7 @@
 		<string>/Library/Application Support/Google/Chrome Beta/NativeMessagingHosts/</string>
 		<string>/Library/Application Support/Google/Chrome Dev/NativeMessagingHosts/</string>
 		<string>/Library/Application Support/Google/Chrome Canary/NativeMessagingHosts/</string>
+		<string>/Library/Application Support/Chromium/NativeMessagingHosts/</string>
 		<string>/Library/Application Support/Microsoft Edge/NativeMessagingHosts/</string>
 		<string>/Library/Application Support/Microsoft Edge Beta/NativeMessagingHosts/</string>
 		<string>/Library/Application Support/Microsoft Edge Dev/NativeMessagingHosts/</string>

--- a/src/main/nativeMessaging.main.ts
+++ b/src/main/nativeMessaging.main.ts
@@ -166,6 +166,7 @@ export class NativeMessagingMain {
             'Chrome Beta': `${this.homedir()}/Library/Application\ Support/Google/Chrome\ Beta/`,
             'Chrome Dev': `${this.homedir()}/Library/Application\ Support/Google/Chrome\ Dev/`,
             'Chrome Canary': `${this.homedir()}/Library/Application\ Support/Google/Chrome\ Canary/`,
+            'Chromium': `${this.homedir()}/Library/Application\ Support/Chromium/`,
             'Microsoft Edge': `${this.homedir()}/Library/Application\ Support/Microsoft\ Edge/`,
             'Microsoft Edge Beta': `${this.homedir()}/Library/Application\ Support/Microsoft\ Edge\ Beta/`,
             'Microsoft Edge Dev': `${this.homedir()}/Library/Application\ Support/Microsoft\ Edge\ Dev/`,


### PR DESCRIPTION
## Overview
Chromium uses a different directory for the native messaging manifests. To avoid future troubleshooting for users we might as well write the manifests in those directories.

Follow up to #804 

Resolves https://github.com/bitwarden/browser/issues/1804