### PR TITLE
Destroy active connections when disabling browser integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1139,6 +1139,15 @@
         "@types/node": "*"
       }
     },
+    "@types/node-ipc": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@types/node-ipc/-/node-ipc-9.1.3.tgz",
+      "integrity": "sha512-ka7CPX9Dk2lwe4PxoZMLOwcQrtdcYe/7OKmH75fQbmt0jdKltWVkdGA81D5l55d0wNhkweHa3XmzFbt5C0ieOQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
     "@types/lunr": "^2.3.3",
     "@types/node": "^10.17.58",
     "@types/node-forge": "^0.9.7",
+    "@types/node-ipc": "^9.1.3",
     "@types/papaparse": "^5.2.0",
     "@types/webcrypto": "^0.0.28",
     "@types/webpack": "^4.4.27",

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,6 +1,2 @@
 declare function escape(s: string): string;
 declare function unescape(s: string): string;
-declare module 'node-ipc' {
-    const x: any;
-    export = x;
-}

--- a/src/main/nativeMessaging.main.ts
+++ b/src/main/nativeMessaging.main.ts
@@ -1,4 +1,5 @@
 import { existsSync, promises as fs } from 'fs';
+import { Socket } from 'net';
 import * as ipc from 'node-ipc';
 import { homedir, userInfo } from 'os';
 import * as path from 'path';
@@ -9,7 +10,7 @@ import { LogService } from 'jslib/abstractions/log.service';
 import { WindowMain } from 'jslib/electron/window.main';
 
 export class NativeMessagingMain {
-    private connected = false;
+    private connected: Socket[] = [];
     private socket: any;
 
     constructor(private logService: LogService, private windowMain: WindowMain, private userPath: string, private exePath: string) {}
@@ -36,14 +37,18 @@ export class NativeMessagingMain {
                 }
             });
 
-            ipc.server.on('connect', () => {
-                this.connected = true;
+            ipc.server.on('connect', (socket: Socket) => {
+                this.connected.push(socket);
             });
 
             ipc.server.on(
                 'socket.disconnected',
-                (socket: any, destroyedSocketID: any) => {
-                    this.connected = false;
+                (socket, destroyedSocketID) => {
+                    const index = this.connected.indexOf(socket);
+                    if (index > -1) {
+                        this.connected.splice(index, 1);
+                    }
+
                     this.socket = null;
                     ipc.log(
                         'client ' + destroyedSocketID + ' has disconnected!'
@@ -57,6 +62,12 @@ export class NativeMessagingMain {
 
     stop() {
         ipc.server.stop();
+        // Kill all existing connections
+        this.connected.forEach(socket => {
+            if (!socket.destroyed) {
+                socket.destroy();
+            }
+        });
     }
 
     send(message: object, socket: any) {
@@ -184,7 +195,7 @@ export class NativeMessagingMain {
 
     private binaryPath() {
         if (process.platform === 'win32') {
-            return path.join(path.basename(this.exePath), 'resources', 'native-messaging.bat');
+            return path.join(path.dirname(this.exePath), 'resources', 'native-messaging.bat');
         }
 
         return this.exePath;

--- a/src/proxy/ipc.ts
+++ b/src/proxy/ipc.ts
@@ -18,10 +18,7 @@ export default class IPC {
         ipc.connectTo('bitwarden', () => {
             ipc.of.bitwarden.on('connect', () => {
                 this.connected = true;
-                console.error(
-                    '## connected to bitwarden desktop ##',
-                    ipc.config.delay
-                );
+                console.error('## connected to bitwarden desktop ##');
 
                 // Notify browser extension, connection is established to desktop application.
                 this.onMessage({command: 'connected'});


### PR DESCRIPTION
## Objective
If a user disables the browser integration from the Desktop app, it doesn't trigger a disconnect in the browser (Observed in Firefox, Chrome and Safari).

### Code Changes
- **package.json**:  Added `@types/node-ipc`.
- **src/global.d.ts**: Removed dummy `node-ipc` module since we now have actual typings
- **src/main/nativeMessaging.main.ts**: Add array of active sockets, and destroy them when closing the socket. Also fixed a bug where the exe path in the manifest was incorrect on Windows.
- **src/proxy/ipc.ts**: `delay` doesn't exist in the config object, so removed it.