### PR TITLE
Add flexbox to cipher list to correct display center issue.

### DIFF
--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -12,20 +12,22 @@
             (scrolled)="loadMore()">
             <a *ngFor="let c of filteredCiphers" appStopClick (click)="selectCipher(c)"
                 (contextmenu)="rightClickCipher(c)" href="#" title="{{'viewItem' | i18n}}"
-                [ngClass]="{'active': c.id === activeCipherId}">
+                [ngClass]="{'active': c.id === activeCipherId}" class="flex-list-item">
                 <app-vault-icon [cipher]="c"></app-vault-icon>
-                <span class="text">
-                    {{c.name}}
-                    <ng-container *ngIf="c.organizationId">
-                        <i class="fa fa-share-alt text-muted" title="{{'shared' | i18n}}" aria-hidden="true"></i>
-                        <span class="sr-only">{{'shared' | i18n}}</span>
-                    </ng-container>
-                    <ng-container *ngIf="c.hasAttachments">
-                        <i class="fa fa-paperclip text-muted" title="{{'attachments' | i18n}}" aria-hidden="true"></i>
-                        <span class="sr-only">{{'attachments' | i18n}}</span>
-                    </ng-container>
-                </span>
-                <span class="detail">{{c.subTitle}}</span>
+                <a class='flex-cipher-list-item'>
+                    <span class="text">
+                        {{c.name}}
+                        <ng-container *ngIf="c.organizationId">
+                            <i class="fa fa-share-alt text-muted" title="{{'shared' | i18n}}" aria-hidden="true"></i>
+                            <span class="sr-only">{{'shared' | i18n}}</span>
+                        </ng-container>
+                        <ng-container *ngIf="c.hasAttachments">
+                            <i class="fa fa-paperclip text-muted" title="{{'attachments' | i18n}}" aria-hidden="true"></i>
+                            <span class="sr-only">{{'attachments' | i18n}}</span>
+                        </ng-container>
+                    </span>
+                    <span *ngIf="c.subTitle" class="detail">{{c.subTitle}}</span>
+                </a>
             </a>
         </div>
         <div class="no-items" *ngIf="!filteredCiphers.length">

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -14,7 +14,7 @@
                 (contextmenu)="rightClickCipher(c)" href="#" title="{{'viewItem' | i18n}}"
                 [ngClass]="{'active': c.id === activeCipherId}" class="flex-list-item">
                 <app-vault-icon [cipher]="c"></app-vault-icon>
-                <a class='flex-cipher-list-item'>
+                <div class="flex-cipher-list-item">
                     <span class="text">
                         {{c.name}}
                         <ng-container *ngIf="c.organizationId">
@@ -27,7 +27,7 @@
                         </ng-container>
                     </span>
                     <span *ngIf="c.subTitle" class="detail">{{c.subTitle}}</span>
-                </a>
+                </div>
             </a>
         </div>
         <div class="no-items" *ngIf="!filteredCiphers.length">

--- a/src/scss/list.scss
+++ b/src/scss/list.scss
@@ -130,4 +130,14 @@
             }
         }
     }
+
+    .flex-cipher-list-item {
+        flex-direction: column;
+        flex-wrap: nowrap;
+        justify-content: center;
+        align-items: flex-start;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
 }


### PR DESCRIPTION
This is a better way to correct the issue in #599 
First pull request I made for this issue was #855 But I closed it because it had side effects.

I've added an additional `<a>` wrapper to implement better flexbox functionality so that the items in question can consistency be centered. This also required adding an additional scss field fo referenced wrapper.

Before: 
<img width="468" alt="Screen Shot 2021-05-03 at 4 33 30 PM" src="https://user-images.githubusercontent.com/16548994/116860569-59373800-ac34-11eb-8afc-b7c9d620660d.png"><img width="245" alt="Screen Shot 2021-05-03 at 4 34 13 PM" src="https://user-images.githubusercontent.com/16548994/116860603-6522fa00-ac34-11eb-8b30-82b1168d0c80.png">

After:
<img width="448" alt="Screen Shot 2021-05-03 at 4 39 29 PM" src="https://user-images.githubusercontent.com/16548994/116860685-84ba2280-ac34-11eb-9991-26c6f26bfb8d.png"><img width="247" alt="Screen Shot 2021-05-03 at 4 39 42 PM" src="https://user-images.githubusercontent.com/16548994/116860700-8b489a00-ac34-11eb-9dca-054ee8dc8ada.png">

I've confirmed that the side effects mentioned in the previous pull request have been corrected. The "After" screenshot above shows the list display of all types (I could not add an attachment to confirm placement, but share notification is there).

Let me know what you think, hope this helps.
