### PR TITLE
Block save button when uploading a send

### DIFF
--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -1,4 +1,4 @@
-<form (ngSubmit)="submit()" [appApiAction]="formPromise">
+<form #form (ngSubmit)="submit()" [appApiAction]="formPromise">
     <div class="content">
         <div class="inner-content" *ngIf="send">
             <div class="box">
@@ -182,10 +182,11 @@
         </div>
     </div>
     <div class="footer">
-        <button appBlurClick type="submit" class="primary" appA11yTitle="{{'save' | i18n}}" *ngIf="!disableSend">
-            <i class="fa fa-save fa-lg fa-fw" aria-hidden="true"></i>
+        <button appBlurClick type="submit" class="primary btn-submit" appA11yTitle="{{'save' | i18n}}" [disabled]="form.loading" *ngIf="!disableSend">
+            <i class="fa fa-spinner fa-spin" title="{{'loading' | i18n}}" aria-hidden="true"></i>
+            <span><i class="fa fa-save fa-lg fa-fw" aria-hidden="true"></i></span>
         </button>
-        <button appBlurClick type="button" (click)="cancel()">
+        <button appBlurClick type="button" (click)="cancel()" [disabled]="form.loading">
             {{'cancel' | i18n}}
         </button>
         <div class="right">

--- a/src/scss/buttons.scss
+++ b/src/scss/buttons.scss
@@ -89,6 +89,7 @@
 
 .btn-submit {
     position: relative;
+    overflow: hidden;
 
     .fa-spinner {
         position: absolute;

--- a/src/scss/buttons.scss
+++ b/src/scss/buttons.scss
@@ -86,3 +86,28 @@
         }
     }
 }
+
+.btn-submit {
+    position: relative;
+
+    .fa-spinner {
+        position: absolute;
+        display: none;
+        align-items: center;
+        justify-content: center;
+        bottom: 0;
+        top: 0;
+        left: 0;
+        right: 0;
+    }
+
+    &:disabled:not(.manual), &.loading {
+        .fa-spinner {
+            display: flex;
+        }
+
+        span {
+            visibility: hidden;
+        }
+    }
+}


### PR DESCRIPTION
## Objective
Add user-feedback when uploading file on send. Useful when uploading a large send since it can take a few moments for the Send to be created. 

### Code Changes
- **src/app/send/add-edit.component.html**: Add spinner when uploading send. Also disabled cancel since it currently did nothing.
- **src/scss/buttons.scss**: Add btn-primary logic used in web vault.

### Screenshots
https://user-images.githubusercontent.com/137855/117011219-e5f1fc80-aced-11eb-93b7-bc3fce4fa1ce.mp4

Related PR: https://github.com/bitwarden/jslib/pull/368
