### PR TITLE
Fix VS code ts language server no longer working after #866

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,2 +1,3 @@
 declare function escape(s: string): string;
 declare function unescape(s: string): string;
+declare module 'forcefocus';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,9 +21,7 @@
   "angularCompilerOptions": {
     "preserveWhitespaces": true
   },
-  "files": [
-    "src/entry.ts",
-    "src/global.d.ts",
-    "jslib/src/globals.d.ts"
+  "include": [
+    "src"
   ]
 }

--- a/tsconfig.renderer.json
+++ b/tsconfig.renderer.json
@@ -1,8 +1,10 @@
 {
   "extends": "./tsconfig.json",
-  "files": [
-    "src/app/main.ts",
-    "src/global.d.ts",
-    "jslib/src/globals.d.ts"
+  "exclude": [
+    "src/entry.ts",
+    "src/main.ts",
+    "src/main",
+    "src/proxy",
+    "jslib/**/*.main.ts"
   ]
 }


### PR DESCRIPTION
## Objective
#866 introduced an issue with TS language server when editing files in vs code. All `jslib` imports produced warnings which was only noticeable after restarting vscode. Since this is obviously an undesired effect I had to make a few tweaks to the tsconfig files to ensure they still works.