### PR TITLE
Add setting for disabling auto prompt of biometrics

### DIFF
--- a/src/app/accounts/lock.component.ts
+++ b/src/app/accounts/lock.component.ts
@@ -7,6 +7,7 @@ import {
     ActivatedRoute,
     Router,
 } from '@angular/router';
+import { ipcRenderer } from 'electron';
 
 import { ApiService } from 'jslib/abstractions/api.service';
 import { CryptoService } from 'jslib/abstractions/crypto.service';
@@ -49,7 +50,11 @@ export class LockComponent extends BaseLockComponent implements OnDestroy {
 
         this.route.queryParams.subscribe(params => {
             if (this.supportsBiometric && params.promptBiometric && autoPromptBiometric) {
-                setTimeout(() => this.unlockBiometric(), 1000);
+                setTimeout(async() => {
+                    if (await ipcRenderer.invoke('windowVisible')) {
+                        this.unlockBiometric();
+                    }
+                }, 1000);
             }
         });
         this.broadcasterService.subscribe(BroadcasterSubscriptionId, async (message: any) => {

--- a/src/app/accounts/lock.component.ts
+++ b/src/app/accounts/lock.component.ts
@@ -23,6 +23,8 @@ import { BroadcasterService } from 'jslib/angular/services/broadcaster.service';
 
 import { LockComponent as BaseLockComponent } from 'jslib/angular/components/lock.component';
 
+import { ElectronConstants } from 'jslib/electron/electronConstants';
+
 const BroadcasterSubscriptionId = 'LockComponent';
 
 @Component({
@@ -43,8 +45,10 @@ export class LockComponent extends BaseLockComponent implements OnDestroy {
 
     async ngOnInit() {
         await super.ngOnInit();
+        const autoPromptBiometric = !await this.storageService.get<boolean>(ElectronConstants.noAutoPromptBiometrics);
+
         this.route.queryParams.subscribe(params => {
-            if (this.supportsBiometric && params.promptBiometric) {
+            if (this.supportsBiometric && params.promptBiometric && autoPromptBiometric) {
                 setTimeout(() => this.unlockBiometric(), 1000);
             }
         });

--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -52,6 +52,15 @@
                                 </label>
                             </div>
                         </div>
+                        <div class="form-group" *ngIf="supportsBiometric">
+                            <div class="checkbox">
+                                <label for="noAutoPromptBiometrics">
+                                    <input id="noAutoPromptBiometrics" type="checkbox" name="noAutoPromptBiometrics" [(ngModel)]="noAutoPromptBiometrics"
+                                        [disabled]="!biometric" (change)="updateNoAutoPromptBiometrics()">
+                                    {{noAutoPromptBiometricsText | i18n}}
+                                </label>
+                            </div>
+                        </div>
                     </div>
                 </div>
                 <div class="box">

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -50,6 +50,8 @@ export class SettingsComponent implements OnInit {
     supportsBiometric: boolean;
     biometric: boolean;
     biometricText: string;
+    noAutoPromptBiometrics: boolean;
+    noAutoPromptBiometricsText: string;
     alwaysShowDock: boolean;
     showAlwaysShowDock: boolean = false;
     openAtLogin: boolean;
@@ -162,6 +164,8 @@ export class SettingsComponent implements OnInit {
         this.supportsBiometric = await this.platformUtilsService.supportsBiometric();
         this.biometric = await this.vaultTimeoutService.isBiometricLockSet();
         this.biometricText = await this.storageService.get<string>(ConstantsService.biometricText);
+        this.noAutoPromptBiometrics = await this.storageService.get<boolean>(ElectronConstants.noAutoPromptBiometrics);
+        this.noAutoPromptBiometricsText = await this.storageService.get<string>(ElectronConstants.noAutoPromptBiometricsText);
         this.alwaysShowDock = await this.storageService.get<boolean>(ElectronConstants.alwaysShowDock);
         this.showAlwaysShowDock = this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop;
         this.openAtLogin = await this.storageService.get<boolean>(ElectronConstants.openAtLogin);
@@ -255,9 +259,23 @@ export class SettingsComponent implements OnInit {
             await this.storageService.save(ConstantsService.biometricUnlockKey, true);
         } else {
             await this.storageService.remove(ConstantsService.biometricUnlockKey);
+            await this.storageService.remove(ElectronConstants.noAutoPromptBiometrics);
+            this.noAutoPromptBiometrics = false;
         }
         this.vaultTimeoutService.biometricLocked = false;
         await this.cryptoService.toggleKey();
+    }
+
+    async updateNoAutoPromptBiometrics() {
+        if (!this.biometric) {
+            this.noAutoPromptBiometrics = false;
+        }
+
+        if (this.noAutoPromptBiometrics) {
+            await this.storageService.save(ElectronConstants.noAutoPromptBiometrics, true);
+        } else {
+            await this.storageService.remove(ElectronConstants.noAutoPromptBiometrics);
+        }
     }
 
     async saveFavicons() {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1297,6 +1297,12 @@
   "touchIdConsentMessage": {
     "message": "unlock your vault"
   },
+  "noAutoPromptWindowsHello": {
+    "message": "Do not prompt for Windows Hello on launch."
+  },
+  "noAutoPromptTouchId": {
+    "message": "Do not prompt for Touch ID on launch."
+  },
   "lockWithMasterPassOnRestart": {
     "message": "Lock with master password on restart"
   },


### PR DESCRIPTION
## Objective
When starting the desktop application on launch or when running using `npm run electron`, the biometrics prompts can be quite annoying. This PR adds a setting to the desktop application for disabling the auto prompt behaviour. It also verifies that the window is visible before prompting for biometrics.

### Code Changes
- **src/app/accounts/lock.component.ts**: Check if no auto prompt is enabled and if so do not prompt for biometrics automatically.
- **src/app/accounts/settings.component.html**: Html for toggle.
- **src/app/accounts/settings.component.ts**: Logic for toggling no auto prompt.
- **src/locales/en/messages.json**: Locale updates.

### Testing Considerations
We should do some quick regression testing to ensure current behavior is unchanged (prompt by default) and the setting works. When starting minimized, no biometric prompt should appear even when option is disabled. When disabling biometrics, this setting should also become disabled.

### Screenshots
![image](https://user-images.githubusercontent.com/137855/117313395-24baba80-ae86-11eb-8e2b-1f318fe9c8af.png)

Depends on https://github.com/bitwarden/jslib/pull/370
Resolves: https://github.com/bitwarden/desktop/issues/711