### PR TITLE
Fix typo in webAuthnAuthenticate

### DIFF
--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1661,7 +1661,7 @@
     "message": "Pending deletion"
   },
   "webAuthnAuthenticate": {
-    "message": "Authenticate WebAutn"
+    "message": "Authenticate WebAuthn"
   },
   "hideEmail": {
     "message": "Hide my email address from recipients."


### PR DESCRIPTION
As reported by user in Crowdin (https://crowdin.com/translate/bitwarden-browser/26/en-de#4816), the source string had a small typo. This PR fixes it.