### PR TITLE
use swal titletext to avoid XSS

### DIFF
--- a/src/services/electronPlatformUtils.service.ts
+++ b/src/services/electronPlatformUtils.service.ts
@@ -18,7 +18,7 @@ export class ElectronPlatformUtilsService extends BaseElectronPlatformUtilsServi
         Promise<boolean> {
         const result = await Swal.fire({
             heightAuto: false,
-            title: title,
+            titleText: title,
             input: 'password',
             text: body,
             confirmButtonText: this.i18nService.t('ok'),

--- a/src/services/nativeMessaging.service.ts
+++ b/src/services/nativeMessaging.service.ts
@@ -53,7 +53,7 @@ export class NativeMessagingService {
 
                 // Await confirmation that fingerprint is correct
                 const submitted = await Swal.fire({
-                    title: this.i18nService.t('verifyBrowserTitle'),
+                    titleText: this.i18nService.t('verifyBrowserTitle'),
                     html: `${this.i18nService.t('verifyBrowserDesc')}<br><br><strong>${fingerprint}</strong>`,
                     showCancelButton: true,
                     cancelButtonText: this.i18nService.t('cancel'),


### PR DESCRIPTION
We dont epect to use HTML in the sweetalert title, so switch to `titleText` property.

https://sweetalert2.github.io/#titleText