### PR TITLE
Fixed locale import for Montenegrin (Latin)

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -90,7 +90,7 @@ import localeIt from '@angular/common/locales/it';
 import localeJa from '@angular/common/locales/ja';
 import localeKo from '@angular/common/locales/ko';
 import localeLv from '@angular/common/locales/lv';
-import localeMe from '@angular/common/locales/me';
+import localeMe from '@angular/common/locales/sr-Latn-ME';
 import localeMl from '@angular/common/locales/ml';
 import localeNb from '@angular/common/locales/nb';
 import localeNl from '@angular/common/locales/nl';


### PR DESCRIPTION
With #897 an import for the Montenegrin locale was wrong, which let the build fail. Based on the two letter code used in Crowdin, I looked up the three letter lang code (**cnr**) on wikipedia and then searched/crossreferenced in [CLDR](https://github.com/unicode-org/cldr) which is used by Angular as source for the locales.