### PR TITLE
Respond to OS theme changes

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -124,6 +124,11 @@ export class AppComponent implements OnInit {
             window.onkeypress = () => this.recordActivity();
         });
 
+        this.platformUtilsService.onDefaultSystemThemeChange(theme => {
+            window.document.documentElement.classList.remove('theme_light', 'theme_dark');
+            window.document.documentElement.classList.add('theme_' + theme);
+        });
+
         this.broadcasterService.subscribe(BroadcasterSubscriptionId, async (message: any) => {
             this.ngZone.run(async () => {
                 switch (message.command) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -124,14 +124,6 @@ export class AppComponent implements OnInit {
             window.onkeypress = () => this.recordActivity();
         });
 
-        this.platformUtilsService.onDefaultSystemThemeChange(async systemTheme => {
-            const theme = await this.storageService.get<string>(ConstantsService.themeKey);
-            if (theme == null) {
-                window.document.documentElement.classList.remove('theme_light', 'theme_dark');
-                window.document.documentElement.classList.add('theme_' + systemTheme);
-            }
-        });
-
         this.broadcasterService.subscribe(BroadcasterSubscriptionId, async (message: any) => {
             this.ngZone.run(async () => {
                 switch (message.command) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -124,9 +124,12 @@ export class AppComponent implements OnInit {
             window.onkeypress = () => this.recordActivity();
         });
 
-        this.platformUtilsService.onDefaultSystemThemeChange(theme => {
-            window.document.documentElement.classList.remove('theme_light', 'theme_dark');
-            window.document.documentElement.classList.add('theme_' + theme);
+        this.platformUtilsService.onDefaultSystemThemeChange(async systemTheme => {
+            const theme = await this.storageService.get<string>(ConstantsService.themeKey);
+            if (theme == null) {
+                window.document.documentElement.classList.remove('theme_light', 'theme_dark');
+                window.document.documentElement.classList.add('theme_' + systemTheme);
+            }
         });
 
         this.broadcasterService.subscribe(BroadcasterSubscriptionId, async (message: any) => {

--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -157,6 +157,10 @@ export function initFactory(): Function {
         let theme = await storageService.get<string>(ConstantsService.themeKey);
         if (theme == null) {
             theme = await platformUtilsService.getDefaultSystemTheme();
+            platformUtilsService.onDefaultSystemThemeChange(sysTheme => {
+                window.document.documentElement.classList.remove('theme_light', 'theme_dark');
+                window.document.documentElement.classList.add('theme_' + sysTheme);
+            });
         }
         htmlEl.classList.add('theme_' + theme);
         stateService.save(ConstantsService.disableFaviconKey,

--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -156,11 +156,7 @@ export function initFactory(): Function {
         htmlEl.classList.add('locale_' + i18nService.translationLocale);
         let theme = await storageService.get<string>(ConstantsService.themeKey);
         if (theme == null) {
-            if (platformUtilsService.getDevice() === DeviceType.MacOsDesktop) {
-                theme = await platformUtilsService.getDefaultSystemTheme();
-            } else {
-                theme = 'light';
-            }
+            theme = await platformUtilsService.getDefaultSystemTheme();
         }
         htmlEl.classList.add('theme_' + theme);
         stateService.save(ConstantsService.disableFaviconKey,


### PR DESCRIPTION
## Objective
* Fix #896, which was caused by a missing null check when calling `windowMain.win.webContents.send` when the system theme changed.
* Once I started looking at this, I found that this message was not caught by anything, and the theme was not updating when the system theme changed. Fix #739, which reported this issue.
* Then I had to consider whether to gate this for MacOS only, as we do when the theme is set initially [here](https://github.com/bitwarden/desktop/blob/c7345197f72be1f95870a089d04a27d2963987ef/src/app/services.module.ts#L159). I'm not sure why we do this, but the [documentation for nativeTheme](https://www.electronjs.org/docs/api/native-theme) doesn't say it's limited to MacOS, and it worked fine for Windows when I tested it. So I removed the MacOS gate when we set the theme initially as well. I'll make sure to mention this for QA; if it's fine here I can update browser as well for consistency.

## Code changes
* jslib: add null check - https://github.com/bitwarden/jslib/pull/397
* `app.component.ts`: use existing platformUtilsService method to catch and action "theme changed" message sent by main process
* `services.module.ts`: remove `if` condition so that all OS' can track the system theme

jslib needs to be merged & bumped first