### PR TITLE
Update pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,9 @@ on:
       - 'gh-pages'
 
 jobs:
-
   cloc:
+    name: CLOC
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
@@ -24,8 +23,8 @@ jobs:
         run: cloc --include-lang TypeScript,JavaScript,HTML,Sass,CSS --vcs git
 
   linux:
+    name: Linux
     runs-on: ubuntu-latest
-
     steps:
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea
@@ -110,6 +109,7 @@ jobs:
 
 
   windows:
+    name: Windows
     runs-on: windows-latest
     steps:
       - name: Set up dotnet
@@ -252,6 +252,7 @@ jobs:
           path: ./dist/chocolatey/bitwarden.${{ env.PACKAGE_VERSION }}.nupkg
 
   macos:
+    name: MacOS
     runs-on: macos-latest
     steps:
       - name: Set up Node

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,39 +73,39 @@ jobs:
         run: npm run dist:lin
 
       - name: Upload .deb artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-amd64.deb
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-amd64.deb
+          if-no-files-found: error
 
       - name: Upload .rpm artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-x86_64.rpm
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-x86_64.rpm
+          if-no-files-found: error
 
       - name: Upload .freebsd artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-x64.freebsd
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-x64.freebsd
+          if-no-files-found: error
 
       - name: Upload .snap artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: bitwarden_${{ env.PACKAGE_VERSION }}_amd64.snap
           path: ./dist/bitwarden_${{ env.PACKAGE_VERSION }}_amd64.snap
+          if-no-files-found: error
 
       - name: Upload .AppImage artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-x86_64.AppImage
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-x86_64.AppImage
+          if-no-files-found: error
 
 
   windows:
@@ -210,46 +210,46 @@ jobs:
           choco pack ./dist/chocolatey/bitwarden.nuspec --version "$env:PACKAGE_VERSION" --out ./dist/chocolatey
 
       - name: Upload portable exe artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-Portable-${{ env.PACKAGE_VERSION }}.exe
           path: ./dist/Bitwarden-Portable-${{ env.PACKAGE_VERSION }}.exe
+          if-no-files-found: error
 
       - name: Upload installer exe artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-Installer-${{ env.PACKAGE_VERSION }}.exe
           path: ./dist/nsis-web/Bitwarden-Installer-${{ env.PACKAGE_VERSION }}.exe
+          if-no-files-found: error
 
       - name: Upload store appx ia32 artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-ia32-store.appx
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-ia32-store.appx
+          if-no-files-found: error
 
       - name: Upload store appx x64 artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-x64-store.appx
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-x64-store.appx
+          if-no-files-found: error
 
       - name: Upload store appx ARM64 artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-arm64-store.appx
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-arm64-store.appx
+          if-no-files-found: error
 
       - name: Upload nupkg artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: bitwarden.${{ env.PACKAGE_VERSION }}.nupkg
           path: ./dist/chocolatey/bitwarden.${{ env.PACKAGE_VERSION }}.nupkg
+          if-no-files-found: error
 
   macos:
     name: MacOS
@@ -318,59 +318,51 @@ jobs:
         run: npm run lint
 
       - name: Create Safari directory
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         shell: pwsh
         run: New-Item ./dist-safari -ItemType Directory -ea 0
 
       - name: Checkout browser extension
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           repository: 'bitwarden/browser'
           path: 'dist-safari/browser'
 
       - name: Build Safari extension
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         shell: pwsh
         run: ./scripts/safari-build.ps1 -skipcheckout -skipoutcopy
 
       - name: Load Safari extension for .dmg
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         shell: pwsh
         run: ./scripts/safari-build.ps1 -copyonly
 
       - name: Build application (dev)
-        if: github.ref != 'refs/heads/master' || github.ref == 'refs/heads/rc'
         run: npm run build
 
       - name: Build application (dist)
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         run: npm run dist:mac
         env:
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
 
       - name: Upload .zip artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-mac.zip
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-mac.zip
+          if-no-files-found: error
 
       - name: Upload .dmg artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}.dmg
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}.dmg
+          if-no-files-found: error
 
       - name: Load Safari extension for App Store
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         shell: pwsh
         run: ./scripts/safari-build.ps1 -mas -copyonly
 
       - name: Build application for App Store
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         run: npm run dist:mac:mas
         env:
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
@@ -379,8 +371,8 @@ jobs:
           SDK_DIR: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/
 
       - name: Upload .pkg artifact
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-universal.pkg
           path: ./dist/mas-universal/Bitwarden-${{ env.PACKAGE_VERSION }}-universal.pkg
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,33 +318,40 @@ jobs:
         run: npm run lint
 
       - name: Create Safari directory
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         shell: pwsh
         run: New-Item ./dist-safari -ItemType Directory -ea 0
 
       - name: Checkout browser extension
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
         with:
           repository: 'bitwarden/browser'
           path: 'dist-safari/browser'
 
       - name: Build Safari extension
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         shell: pwsh
         run: ./scripts/safari-build.ps1 -skipcheckout -skipoutcopy
 
       - name: Load Safari extension for .dmg
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         shell: pwsh
         run: ./scripts/safari-build.ps1 -copyonly
 
       - name: Build application (dev)
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         run: npm run build
 
       - name: Build application (dist)
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         run: npm run dist:mac
         env:
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
 
       - name: Upload .zip artifact
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-mac.zip
@@ -352,6 +359,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload .dmg artifact
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}.dmg
@@ -359,10 +367,12 @@ jobs:
           if-no-files-found: error
 
       - name: Load Safari extension for App Store
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         shell: pwsh
         run: ./scripts/safari-build.ps1 -mas -copyonly
 
       - name: Build application for App Store
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         run: npm run dist:mac:mas
         env:
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
@@ -371,6 +381,7 @@ jobs:
           SDK_DIR: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/
 
       - name: Upload .pkg artifact
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-universal.pkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -340,7 +340,7 @@ jobs:
         run: ./scripts/safari-build.ps1 -copyonly
 
       - name: Build application (dev)
-        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+        if: github.ref != 'refs/heads/master' || github.ref != 'refs/heads/rc'
         run: npm run build
 
       - name: Build application (dist)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,9 +10,9 @@ on:
     types:
       - published
 
-
 jobs:
   setup:
+    name: Setup
     runs-on: ubuntu-latest
     outputs:
       package_version: ${{ steps.create_tags.outputs.package_version }}
@@ -52,7 +52,6 @@ jobs:
         env:
           RELEASE_TAG_NAME_INPUT: ${{ github.event.inputs.release_tag_name_input }}
 
-
   snap:
     name: Deploy Snap
     runs-on: ubuntu-latest
@@ -69,10 +68,10 @@ jobs:
         with:
           snapcraft_token: ${{ secrets.SNAP_TOKEN }}
 
-      - name: setup
+      - name: Setup
         run: mkdir dist
 
-      - name: get snap package
+      - name: Get snap package
         uses: Xotl/cool-github-releases@16c58a5863d6ba9944f63ca8bb78bb3249ce1d81
         with:
           mode: download
@@ -80,14 +79,13 @@ jobs:
           assets: bitwarden_${{ env.PKG_VERSION }}_amd64.snap|./dist/bitwarden_${{ env.PKG_VERSION }}_amd64.snap
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: test
+      - name: Test
         run: ls -alht dist
 
       - name: Deploy to Snap Store
         run: |
           snapcraft upload dist/bitwarden_${{ env.PKG_VERSION }}_amd64.snap --release stable
           snapcraft logout
-
 
   choco:
     name: Deploy Choco
@@ -113,7 +111,7 @@ jobs:
         env:
           CHOCO_API_KEY: ${{ secrets.CHOCO_API_KEY }}
 
-      - name: make dist dir 
+      - name: Make dist dir 
         shell: pwsh
         run: New-Item -ItemType directory -Path ./dist
 
@@ -131,8 +129,8 @@ jobs:
           cd dist
           choco push
 
-
   macos:
+    name: Deploy MacOS
     runs-on: macos-latest
     needs: setup
     env:
@@ -142,10 +140,10 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
-      - name: make target directory
+      - name: Make target directory
         run: mkdir -p dist/mas-universal
 
-      - name: Get mac release asset
+      - name: Get Mac release asset
         uses: Xotl/cool-github-releases@16c58a5863d6ba9944f63ca8bb78bb3249ce1d81
         with:
           mode: download

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,9 +6,6 @@ on:
       release_tag_name_input:
         description: "Release Tag Name <X.X.X>"
         required: true
-  release:
-    types:
-      - published
 
 jobs:
   setup:
@@ -156,3 +153,24 @@ jobs:
         env:
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: 
+      - setup
+      - snap
+      - choco
+      - macos
+    env:
+      RELEASE_VERSION: ${{ needs.setup.outputs.release_version }}
+      TAG_VERSION: ${{ needs.setup.outputs.tag_version }}
+    steps:
+      - name: Publish release
+        run: |
+          hub release edit \
+            --draft=false \
+            --message "" \
+            $TAG_VERSION
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ on:
         description: 'Browser Extension ref (defaults to `master`):'
         default: master
 
-
 jobs:
   setup:
+    name: Setup
     runs-on: ubuntu-latest
     outputs:
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
@@ -50,8 +50,8 @@ jobs:
           draft: true
           prerelease: false
 
-
   linux:
+    name: Linux
     runs-on: ubuntu-latest
     needs: setup
     steps:
@@ -97,8 +97,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-
   windows-signed:
+    name: Windows Signed
     runs-on: windows-latest
     needs: setup
     steps:
@@ -203,8 +203,8 @@ jobs:
           asset_path: ./dist/chocolatey/bitwarden.${{ env.PACKAGE_VERSION }}.nupkg
           asset_content_type: application
 
-
   windows-store:
+    name: Windows Store
     runs-on: windows-latest
     needs: setup
     steps:
@@ -281,6 +281,7 @@ jobs:
           asset_content_type: application
 
   macos:
+    name: MacOS
     runs-on: macos-latest
     needs: setup
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,15 @@ jobs:
     outputs:
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
+      - name: Branch check
+        run: |
+          if [[ "$GITHUB_REF" != "refs/heads/rc" ]]; then
+            echo "==================================="
+            echo "[!] Can only release from rc branch"
+            echo "==================================="
+            exit 1
+          fi
+
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 


### PR DESCRIPTION
- Trigger `deploy` workflow manually
- Publish release draft at the end of the `deploy` workflow
- Enable artifact uploads (except MacOS) on all branches
- On asset upload, if asset is not found, error instead of warn