### PR TITLE
Bump version to 1.26.5

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -2,7 +2,7 @@
   "name": "bitwarden",
   "productName": "Bitwarden",
   "description": "A secure and free password manager for all of your devices.",
-  "version": "1.26.4",
+  "version": "1.26.5",
   "author": "Bitwarden Inc. <hello@bitwarden.com> (https://bitwarden.com)",
   "homepage": "https://bitwarden.com",
   "license": "GPL-3.0",


### PR DESCRIPTION
I forgot to bump the version on `master` when we did the hotfix for `rc` #931 