### PR TITLE
Always get key from storage to ensure biometric prompt.

### DIFF
--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -29,7 +29,6 @@ import { CipherService } from 'jslib-common/services/cipher.service';
 import { CollectionService } from 'jslib-common/services/collection.service';
 import { ConstantsService } from 'jslib-common/services/constants.service';
 import { ContainerService } from 'jslib-common/services/container.service';
-import { CryptoService } from 'jslib-common/services/crypto.service';
 import { EnvironmentService } from 'jslib-common/services/environment.service';
 import { EventService } from 'jslib-common/services/event.service';
 import { ExportService } from 'jslib-common/services/export.service';
@@ -50,6 +49,8 @@ import { TotpService } from 'jslib-common/services/totp.service';
 import { UserService } from 'jslib-common/services/user.service';
 import { VaultTimeoutService } from 'jslib-common/services/vaultTimeout.service';
 import { WebCryptoFunctionService } from 'jslib-common/services/webCryptoFunction.service';
+
+import { ElectronCryptoService } from 'jslib-electron/services/electronCrypto.service';
 
 import { ApiService as ApiServiceAbstraction } from 'jslib-common/abstractions/api.service';
 import { AuditService as AuditServiceAbstraction } from 'jslib-common/abstractions/audit.service';
@@ -96,7 +97,7 @@ const platformUtilsService = new ElectronPlatformUtilsService(i18nService, messa
 const secureStorageService: StorageServiceAbstraction = new ElectronRendererSecureStorageService();
 const cryptoFunctionService: CryptoFunctionServiceAbstraction = new WebCryptoFunctionService(window,
     platformUtilsService);
-const cryptoService = new CryptoService(storageService, secureStorageService, cryptoFunctionService,
+const cryptoService = new ElectronCryptoService(storageService, secureStorageService, cryptoFunctionService,
     platformUtilsService, logService);
 const tokenService = new TokenService(storageService);
 const appIdService = new AppIdService(storageService);

--- a/src/services/nativeMessaging.service.ts
+++ b/src/services/nativeMessaging.service.ts
@@ -102,7 +102,7 @@ export class NativeMessagingService {
                     });
                 }
 
-                const keyB64 = await (await this.cryptoService.getKey('biometric')).keyB64;
+                const keyB64 = await (await this.cryptoService.getKeyFromStorage('biometric')).keyB64;
 
                 if (keyB64 != null) {
                     this.send({ command: 'biometricUnlock', response: 'unlocked', keyB64: keyB64 }, appId);


### PR DESCRIPTION
# Overview

@Hinton noticed some issues with biometric unlock from browser introduced in bitwarden/jslib#402 and #946.

Depends on bitwarden/jslib#408.

# Files Changed
* **nativeMessageing.service.ts**: Use the new `getKeyFromStrorage` method to ensure a biometric prompt is _always_ shown when browser requests biometric authentication. This method will re-read the key (if it exists) from storage any time it is called and a biometric key is always prompted when read.

