### PR TITLE
[Toast] - BUG - Fixed styles

### DIFF
--- a/src/scss/plugins.scss
+++ b/src/scss/plugins.scss
@@ -5,9 +5,10 @@ $fa-font-path: "~font-awesome/fonts";
 
 @import "variables.scss";
 
-#toast-container {
+.toast-container {
     .toast-close-button {
-        right: -0.15em;
+        margin-right: 4px;
+        font-size: 18px;
     }
 
     .toast {
@@ -28,8 +29,11 @@ $fa-font-path: "~font-awesome/fonts";
             line-height: 20px;
             float: left;
             color: #ffffff;
-            padding-right: 10px;
-            margin: auto 0 auto -36px;
+            margin: auto 0 auto 15px;
+        }
+
+        .toast-content {
+            padding: 15px;
         }
 
         .toaster-icon {
@@ -55,7 +59,6 @@ $fa-font-path: "~font-awesome/fonts";
 
             &:before {
                 content: "\f0e7";
-                margin-left: -30px;
             }
         }
 


### PR DESCRIPTION
## Objective
> A recent update to the `angular2-toast` library cause our custom styling to not be applied properly.

## Code Changes
- **plugins.scss**: The `toast-container` object is now a `class` and not an `id`. Updated some padding/margin to more closely match the current production toasts style.

## Screenshots
![1-desktop-all](https://user-images.githubusercontent.com/26154748/122258440-a6930000-ce96-11eb-829e-cc65493e5205.png)

