### PR TITLE
Redefine cipher "share" to "move to organization"

### DIFF
--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -370,9 +370,9 @@
             {{'cancel' | i18n}}
         </button>
         <div class="right">
-            <button appBlurClick type="button" (click)="share()" appA11yTitle="{{'shareItem' | i18n}}"
+            <button appBlurClick type="button" (click)="share()" appA11yTitle="{{'moveToOrganization' | i18n}}"
                 *ngIf="editMode && cipher && !cipher.organizationId && !cloneMode">
-                <i class="fa fa-share-alt fa-lg fa-fw" aria-hidden="true"></i>
+                <i class="fa fa-arrow-circle-o-right fa-lg fa-fw" aria-hidden="true"></i>
             </button>
             <button #deleteBtn appBlurClick type="button" (click)="delete()" class="danger"
                 appA11yTitle="{{'delete' | i18n}}" *ngIf="editMode && !cloneMode" [disabled]="deleteBtn.loading"

--- a/src/app/vault/ciphers.component.html
+++ b/src/app/vault/ciphers.component.html
@@ -18,7 +18,7 @@
                     <span class="text">
                         {{c.name}}
                         <ng-container *ngIf="c.organizationId">
-                            <i class="fa fa-share-alt text-muted" title="{{'shared' | i18n}}" aria-hidden="true"></i>
+                            <i class="fa fa-cube text-muted" title="{{'shared' | i18n}}" aria-hidden="true"></i>
                             <span class="sr-only">{{'shared' | i18n}}</span>
                         </ng-container>
                         <ng-container *ngIf="c.hasAttachments">

--- a/src/app/vault/share.component.html
+++ b/src/app/vault/share.component.html
@@ -1,10 +1,10 @@
-<div class="modal fade" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="shareTitle">
+<div class="modal fade" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="moveSelectedToOrgTitle">
     <div class="modal-dialog" role="document">
         <form class="modal-content" #form (ngSubmit)="submit()" [appApiAction]="formPromise">
             <div class="modal-body">
                 <div class="box">
-                    <div class="box-header" id="shareTitle">
-                        {{'share' | i18n}}
+                    <div class="box-header" id="moveSelectedToOrgTitle">
+                        {{'moveToOrganization' | i18n}}
                     </div>
                     <div class="box-content" *ngIf="!organizations || !organizations.length">
                         <div class="box-content-row">
@@ -21,7 +21,7 @@
                         </div>
                     </div>
                     <div class="box-footer">
-                        {{'shareDesc' | i18n}}
+                        {{'moveToOrgDesc' | i18n}}
                     </div>
                 </div>
                 <div class="box" *ngIf="organizations && organizations.length">

--- a/src/app/vault/share.component.html
+++ b/src/app/vault/share.component.html
@@ -1,9 +1,9 @@
-<div class="modal fade" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="moveSelectedToOrgTitle">
+<div class="modal fade" tabindex="-1" role="dialog" aria-modal="true" aria-labelledby="moveToOrgTitle">
     <div class="modal-dialog" role="document">
         <form class="modal-content" #form (ngSubmit)="submit()" [appApiAction]="formPromise">
             <div class="modal-body">
                 <div class="box">
-                    <div class="box-header" id="moveSelectedToOrgTitle">
+                    <div class="box-header" id="moveToOrgTitle">
                         {{'moveToOrganization' | i18n}}
                     </div>
                     <div class="box-content" *ngIf="!organizations || !organizations.length">

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -44,14 +44,24 @@
   "share": {
     "message": "Share"
   },
-  "shareItem": {
-    "message": "Share Item"
+  "moveToOrganization": {
+    "message": "Move to Organization"
   },
-  "sharedItem": {
-    "message": "Shared Item"
+  "movedItemToOrg": {
+    "message": "$ITEMNAME$ moved to $ORGNAME$",
+    "placeholders": {
+      "itemname": {
+        "content": "$1",
+        "example": "Secret Item"
+      },
+      "orgname": {
+        "content": "$2",
+        "example": "Company Name"
+      }
+    }
   },
-  "shareDesc": {
-    "message": "Choose an organization that you wish to share this item with. Sharing transfers ownership of the item to the organization. You will no longer be the direct owner of this item once it has been shared."
+  "moveToOrgDesc": {
+    "message": "Choose an organization that you wish to move this item to. Moving to an organization transfers ownership of the item to that organization. You will no longer be the direct owner of this item once it has been moved."
   },
   "attachments": {
     "message": "Attachments"


### PR DESCRIPTION
# Overview

The term "Share" is confusing to users because it implies maintaining ownership and control of a cipher while allowing others to access it as well. It also implies the ability to revoke access or to stop sharing -- neither of these things is true.

In addition to the share term being misleading, the [`fa-share-alt`](https://fontawesome.com/v4.7/icon/share-alt) icon implies a forking of the cipher item rather than transferring ownership.

When a cipher is "shared" it is irrevocably taken over by an organization. This occurs for good cryptographic and security reasons. The better solution to this is to revise the communication around "sharing." To that end, this work changes the term "share" to "move to organization" and the icon is changed to [`fa-cube`](https://fontawesome.com/v4.7/icon/cube), which is used to indicate a collection. The act of moving an item to an organization is denoted by [`fa-arrow-circle-o-right`](https://fontawesome.com/v4.7/icon/arrow-circle-o-right) rather than `fa-share-alt`.

# Screen shots
#### Organization owned item in list
<img width="204" alt="image" src="https://user-images.githubusercontent.com/18214891/122436853-c7268d00-cf5e-11eb-9ce3-a0bace357370.png">

#### Move to organization button
<img width="413" alt="image" src="https://user-images.githubusercontent.com/18214891/122436968-e02f3e00-cf5e-11eb-8912-a5dd3d60a42d.png">

#### Move to organization component
<img width="493" alt="image" src="https://user-images.githubusercontent.com/18214891/122437024-ede4c380-cf5e-11eb-835c-68488ea0b999.png">

#### Move to organization success toast
<img width="493" alt="image" src="https://user-images.githubusercontent.com/18214891/122437083-fd640c80-cf5e-11eb-9574-62e3161fd09e.png">