### PR TITLE
fixed the icon for sends being swapped between file and text sends

### DIFF
--- a/src/app/send/send.component.html
+++ b/src/app/send/send.component.html
@@ -45,7 +45,7 @@
                     title="{{'viewItem' | i18n}}" (contextmenu)="viewSendMenu(s)"
                     [ngClass]="{'active': s.id === sendId}" class="flex-list-item">
                     <div class="item-icon" aria-hidden="true">
-                        <i class="fa fa-fw fa-lg" [ngClass]="s.type == 0 ? 'fa-file-o' : 'fa-file-text-o'"></i>
+                        <i class="fa fa-fw fa-lg" [ngClass]="s.type == 0 ? 'fa-file-text-o' : 'fa-file-o'"></i>
                     </div>
                     <div class="item-content">
                         <div class="item-title">


### PR DESCRIPTION
Resolves https://app.asana.com/0/1199950673439194/1200515179495371/f
The icons for Bitwarden Send are backwards on desktop, this flips them around.