### PR TITLE
[macOS] Don't enable secure input when app is not in focus

### DIFF
--- a/src/app/accounts/lock.component.html
+++ b/src/app/accounts/lock.component.html
@@ -8,12 +8,12 @@
                     <div class="row-main" *ngIf="pinLock">
                         <label for="pin">{{'pin' | i18n}}</label>
                         <input id="pin" type="{{showPassword ? 'text' : 'password'}}" name="PIN" class="monospaced"
-                            [(ngModel)]="pin" required appAutofocus>
+                            [(ngModel)]="pin" required>
                     </div>
                     <div class="row-main" *ngIf="!pinLock">
                         <label for="masterPassword">{{'masterPass' | i18n}}</label>
                         <input id="masterPassword" type="{{showPassword ? 'text' : 'password'}}" name="MasterPassword"
-                            class="monospaced" [(ngModel)]="masterPassword" required appAutofocus>
+                            class="monospaced" [(ngModel)]="masterPassword" required>
                     </div>
                     <div class="action-buttons">
                         <a class="row-btn" href="#" appStopClick appBlurClick role="button"

--- a/src/app/accounts/lock.component.ts
+++ b/src/app/accounts/lock.component.ts
@@ -33,6 +33,8 @@ const BroadcasterSubscriptionId = 'LockComponent';
     templateUrl: 'lock.component.html',
 })
 export class LockComponent extends BaseLockComponent implements OnDestroy {
+    private deferFocus: boolean = null;
+
     constructor(router: Router, i18nService: I18nService,
         platformUtilsService: PlatformUtilsService, messagingService: MessagingService,
         userService: UserService, cryptoService: CryptoService,
@@ -63,10 +65,22 @@ export class LockComponent extends BaseLockComponent implements OnDestroy {
                     case 'windowHidden':
                         this.onWindowHidden();
                         break;
+                    case 'windowIsFocused':
+                        if (this.deferFocus === null) {
+                            this.deferFocus = !message.windowIsFocused;
+                            if (!this.deferFocus) {
+                                this.focusInput();
+                            }
+                        } else if (this.deferFocus && message.windowIsFocused) {
+                            this.focusInput();
+                            this.deferFocus = false;
+                        }
+                        break;
                     default:
                 }
             });
         });
+        this.messagingService.send('getWindowIsFocused');
     }
 
     ngOnDestroy() {
@@ -75,5 +89,9 @@ export class LockComponent extends BaseLockComponent implements OnDestroy {
 
     onWindowHidden() {
         this.showPassword = false;
+    }
+
+    private focusInput() {
+        document.getElementById(this.pinLock ? 'pin' : 'masterPassword').focus();
     }
 }

--- a/src/app/accounts/login.component.ts
+++ b/src/app/accounts/login.component.ts
@@ -22,8 +22,6 @@ import { StateService } from 'jslib-common/abstractions/state.service';
 import { StorageService } from 'jslib-common/abstractions/storage.service';
 import { SyncService } from 'jslib-common/abstractions/sync.service';
 
-import { Utils } from 'jslib-common/misc/utils';
-
 import { BroadcasterService } from 'jslib-angular/services/broadcaster.service';
 
 import { LoginComponent as BaseLoginComponent } from 'jslib-angular/components/login.component';
@@ -39,8 +37,6 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
     @ViewChild('environment', { read: ViewContainerRef, static: true }) environmentModal: ViewContainerRef;
 
     showingModal = false;
-
-    protected focusInputOnPageLoad = process.platform !== 'darwin';
 
     private deferFocus: boolean = null;
 

--- a/src/app/accounts/login.component.ts
+++ b/src/app/accounts/login.component.ts
@@ -22,6 +22,8 @@ import { StateService } from 'jslib-common/abstractions/state.service';
 import { StorageService } from 'jslib-common/abstractions/storage.service';
 import { SyncService } from 'jslib-common/abstractions/sync.service';
 
+import { Utils } from 'jslib-common/misc/utils';
+
 import { BroadcasterService } from 'jslib-angular/services/broadcaster.service';
 
 import { LoginComponent as BaseLoginComponent } from 'jslib-angular/components/login.component';
@@ -37,6 +39,8 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
     @ViewChild('environment', { read: ViewContainerRef, static: true }) environmentModal: ViewContainerRef;
 
     showingModal = false;
+    
+    protected focusInputOnPageLoad = process.platform !== 'darwin';
 
     private deferFocus: boolean = null;
 

--- a/src/app/accounts/login.component.ts
+++ b/src/app/accounts/login.component.ts
@@ -15,6 +15,7 @@ import { AuthService } from 'jslib-common/abstractions/auth.service';
 import { CryptoFunctionService } from 'jslib-common/abstractions/cryptoFunction.service';
 import { EnvironmentService } from 'jslib-common/abstractions/environment.service';
 import { I18nService } from 'jslib-common/abstractions/i18n.service';
+import { MessagingService } from 'jslib-common/abstractions/messaging.service';
 import { PasswordGenerationService } from 'jslib-common/abstractions/passwordGeneration.service';
 import { PlatformUtilsService } from 'jslib-common/abstractions/platformUtils.service';
 import { StateService } from 'jslib-common/abstractions/state.service';
@@ -37,12 +38,14 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
 
     showingModal = false;
 
+    private deferFocus: boolean = null;
+
     constructor(authService: AuthService, router: Router, i18nService: I18nService,
         syncService: SyncService, private componentFactoryResolver: ComponentFactoryResolver,
         platformUtilsService: PlatformUtilsService, stateService: StateService,
         environmentService: EnvironmentService, passwordGenerationService: PasswordGenerationService,
         cryptoFunctionService: CryptoFunctionService, storageService: StorageService,
-        private broadcasterService: BroadcasterService, private ngZone: NgZone) {
+        private broadcasterService: BroadcasterService, private ngZone: NgZone, private messagingService: MessagingService) {
         super(authService, router, platformUtilsService, i18nService, stateService, environmentService,
             passwordGenerationService, cryptoFunctionService, storageService);
         super.onSuccessfulLogin = () => {
@@ -58,10 +61,22 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
                     case 'windowHidden':
                         this.onWindowHidden();
                         break;
+                    case 'windowIsFocused':
+                        if (this.deferFocus === null) {
+                            this.deferFocus = !message.windowIsFocused;
+                            if (!this.deferFocus) {
+                                this.focusInput();
+                            }
+                        } else if (this.deferFocus && message.windowIsFocused) {
+                            this.focusInput();
+                            this.deferFocus = false;
+                        }
+                        break;
                     default:
                 }
             });
         });
+        this.messagingService.send('getWindowIsFocused');
     }
 
     ngOnDestroy() {

--- a/src/app/accounts/login.component.ts
+++ b/src/app/accounts/login.component.ts
@@ -39,7 +39,7 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
     @ViewChild('environment', { read: ViewContainerRef, static: true }) environmentModal: ViewContainerRef;
 
     showingModal = false;
-    
+
     protected focusInputOnPageLoad = process.platform !== 'darwin';
 
     private deferFocus: boolean = null;
@@ -49,7 +49,8 @@ export class LoginComponent extends BaseLoginComponent implements OnDestroy {
         platformUtilsService: PlatformUtilsService, stateService: StateService,
         environmentService: EnvironmentService, passwordGenerationService: PasswordGenerationService,
         cryptoFunctionService: CryptoFunctionService, storageService: StorageService,
-        private broadcasterService: BroadcasterService, private ngZone: NgZone, private messagingService: MessagingService) {
+        private broadcasterService: BroadcasterService, private ngZone: NgZone,
+        private messagingService: MessagingService) {
         super(authService, router, platformUtilsService, i18nService, stateService, environmentService,
             passwordGenerationService, cryptoFunctionService, storageService);
         super.onSuccessfulLogin = () => {

--- a/src/main/messaging.main.ts
+++ b/src/main/messaging.main.ts
@@ -60,6 +60,9 @@ export class MessagingMain {
             case 'setFocus':
                 this.setFocus();
                 break;
+            case 'getWindowIsFocused':
+                this.windowIsFocused();
+                break;
             case 'enableBrowserIntegration':
                 this.main.nativeMessagingMain.generateManifests();
                 this.main.nativeMessagingMain.listen();
@@ -138,5 +141,13 @@ Terminal=false`;
     private setFocus() {
         this.main.trayMain.restoreFromTray();
         this.main.windowMain.win.focusOnWebView();
+    }
+
+    private windowIsFocused() {
+        const windowIsFocused = this.main.windowMain.win.isFocused();
+        this.main.windowMain.win.webContents.send('messagingService', {
+            command: 'windowIsFocused',
+            windowIsFocused: windowIsFocused,
+        });
     }
 }


### PR DESCRIPTION
## Objective

Fix #298: 
> Bitwarden keeps keyboard focus active in the Master Password field, even when it's in the background. When secure keyboard input is active, system-wide keyboard macro software is unable to function (in my case, Keyboard Maestro).

Secure input is a feature provided by macOS to stop other programs from eavesdropping when entering sensitive information. This is fine when the desktop app is actually in use. However, holding secure input open like this when the app is in the background breaks productivity and accessibility applications, which need to be able to read keypresses to function properly.

Electron seems to handle secure input properly in general. If you're using the app and then click away from it, secure input will be released. This issue only occurs when the app loads or navigates in the background - for example:
* opening the app and then clicking away before Electron loads the page
* when the timeout action occurs

Therefore, this only affects the lock and login pages.

## Code changes

The ideal fix here is to use the Electron API to enable secure input when required, and disable it when it's not required: https://www.electronjs.org/docs/api/app#appsetsecurekeyboardentryenabledenabled-macos

However, this just didn't work for me. Disabling secure input did not have any affect on the behaviour.  Wish I had a better explanation here!

Instead, I've taken the following approach. Secure input is only enabled if a password input element is focused. Therefore, on the lock and login pages, I've delayed setting the default focus on the input elements until the window itself has focus. Once the window has had focus after the initial page load, Electron will properly handle the secure input from there.

Note that we do this for all operating systems, not just macOS. It's only needed for macOS, but it kept it simpler and more consistent just to do it for everyone, and I couldn't see any obvious downsides to this. However I can insert `process.platform === 'darwin'` gates if required.

Related jslib PR: https://github.com/bitwarden/jslib/pull/419. Build failures are caused by jslib changes.