### PR TITLE
Add SDKROOT to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -420,6 +420,8 @@ jobs:
         env:
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+          SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/
+          SDK_DIR: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/
 
       - name: Upload Apple Store release asset
         uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2


### PR DESCRIPTION
## Objective
#925 fixed the build issues for the regular pipeline. However I forgot to add it to the `release` workflow.