### PR TITLE
Change the default browser extension branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
         required: true
       browser_extension_ref:
         description: 'Browser Extension ref (defaults to `master`):'
-        default: master
+        default: rc
 
 jobs:
   setup:


### PR DESCRIPTION
## Summary
We should be releasing the `rc` version of the browser extension, so it makes more sense to be setting the default to `rc` instead of `master` so that we have less potential for a slip up releasing the wrong one.