### PR TITLE
fixing the delayed release logic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,8 +154,9 @@ jobs:
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
 
-  publish:
-    name: Publish Release
+
+  auto-updater-deploy:
+    name: Release auto-updater files
     runs-on: ubuntu-latest
     needs: 
       - setup
@@ -166,11 +167,61 @@ jobs:
       RELEASE_VERSION: ${{ needs.setup.outputs.release_version }}
       TAG_VERSION: ${{ needs.setup.outputs.tag_version }}
     steps:
-      - name: Publish release
+      - name: Checkout repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+
+      - name: Rename publish asset
         run: |
-          hub release edit \
-            --draft=false \
-            --message "" \
-            $TAG_VERSION
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          curl \
+              -H "Authorization:token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept:application/vnd.github.v3+json" \
+              https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
+              | jq -r " .[] | select( .tag_name == \"$TAG_VERSION\")" > release.json
+
+          echo "=====RELEASE====="
+          echo Release:
+          #cat release.json
+
+          RELEASE_UPLOAD_URL=$(cat release.json | jq -r ' .upload_url ' | cut -d { -f 1)
+          cat release.json | jq -rc ' .assets[] | select( .name | test("prerelease-latest.*[yml|json]")) | {name: .name,  url: .url, content_type: .content_type}' > release_assets.jsonl
+
+          echo "=====ASSETS====="
+          echo Release Upload URL: $RELEASE_UPLOAD_URL
+          echo Release Assets:
+          cat release_assets.jsonl
+
+          while read -r asset; do 
+              FILE_NAME=$(echo $asset | jq -r '.name')
+              FILE_URL=$(echo $asset | jq -r '.url')
+              FILE_ID=$(echo $asset | jq -r '.id')
+              echo "Asset name: $FILE_NAME"
+              echo "Asset url: $FILE_URL"
+
+              echo "Grabbing asset..."
+              curl \
+                  -L -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Accept: application/octet-stream" \
+                  $FILE_URL --output  $FILE_NAME
+
+              NEW_FILE_SIZE=$(wc -c < $FILE_NAME | xargs)
+              NEW_FILE_NAME=$(echo $FILE_NAME | awk '{split($0,a,"prerelease-"); print a[2]}')
+              echo "New file size: $NEW_FILE_SIZE"
+              echo "New file name: $NEW_FILE_NAME"
+              echo "================"
+
+              echo "Deleting remote asset..."
+              curl \
+                  -X DELETE \
+                  -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "accept: application/vnd.github.v3+json" \
+                  $FILE_URL
+
+              echo "Pushing updated asset..."
+              curl \
+                  -X POST \
+                  -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "content-type: text/yaml" \
+                  -H "content-length: $NEW_FILE_SIZE" \
+                  --data-binary @$FILE_NAME \
+                  "$RELEASE_UPLOAD_URL?name=$NEW_FILE_NAME" --http1.1
+          done < release_assets.jsonl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,3 +432,71 @@ jobs:
           asset_name: Bitwarden-${{ env.PACKAGE_VERSION }}-universal.pkg
           asset_path: ./dist/mas-universal/Bitwarden-${{ env.PACKAGE_VERSION }}-universal.pkg
           asset_content_type: application
+
+
+  update-release-assets:
+    runs-on: ubuntu-latest
+    needs: 
+     - setup
+     - linux
+    env:
+      PKG_VERSION: ${{ needs.setup.outputs.package_version }}
+      TAG_VERSION: ${{ needs.setup.outputs.tag_version }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+
+      - name: Rename publish asset
+        run: |
+          curl \
+              -H "Authorization:token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept:application/vnd.github.v3+json" \
+              https://api.github.com/repos/$GITHUB_REPOSITORY/releases \
+              | jq -r " .[] | select( .tag_name == \"$TAG_VERSION\")" > release.json
+
+          echo "=====RELEASE====="
+          echo Release:
+          #cat release.json
+
+          RELEASE_UPLOAD_URL=$(cat release.json | jq -r ' .upload_url ' | cut -d { -f 1)
+          cat release.json | jq -rc ' .assets[] | select( .name | test("latest.*[yml|json]")) | {name: .name,  url: .url, content_type: .content_type}' > release_assets.jsonl
+
+          echo "=====ASSETS====="
+          echo Release Upload URL: $RELEASE_UPLOAD_URL
+          echo Release Assets:
+          cat release_assets.jsonl
+
+          while read -r asset; do 
+              FILE_NAME=$(echo $asset | jq -r '.name')
+              FILE_URL=$(echo $asset | jq -r '.url')
+              FILE_ID=$(echo $asset | jq -r '.id')
+              echo "Asset name: $FILE_NAME"
+              echo "Asset url: $FILE_URL"
+
+              echo "Grabbing asset..."
+              curl \
+                  -L -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "Accept: application/octet-stream" \
+                  $FILE_URL --output  $FILE_NAME
+
+              NEW_FILE_SIZE=$(wc -c < $FILE_NAME | xargs)
+              echo "New file size: $NEW_FILE_SIZE"
+              echo "New file name: $FILE_NAME"
+              echo "================"
+
+              echo "Deleting remote asset..."
+              curl \
+                  -X DELETE \
+                  -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "accept: application/vnd.github.v3+json" \
+                  $FILE_URL
+
+              echo "Pushing updated asset..."
+              curl \
+                  -X POST \
+                  -H "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                  -H "content-type: text/yaml" \
+                  -H "content-length: $NEW_FILE_SIZE" \
+                  --data-binary @$FILE_NAME \
+                  "$RELEASE_UPLOAD_URL?name=prerelease-$FILE_NAME" --http1.1
+          done < release_assets.jsonl


### PR DESCRIPTION
## Summary
With the current CI pattern of build/release/deploy, the desktop auto-updater logic is created in the `release` portion of the pipeline which creates an issue if the `deploy` job breaks for some reason. We don't want to release the auto-updater files until everything has passed.

To achieve this, I have written some bash to rename the `latest*` files and attach them to the release so that we can rename them back to the originals in the `deploy` pipeline.

## Notes
- The logic here was thoroughly tested in a personal fork to make sure that the e2e release/deploy process worked as expected.