### PR TITLE
Remove dependency on duo_web_sdk and updated jslib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@bitwarden/jslib-common": "file:jslib/common",
         "@bitwarden/jslib-electron": "file:jslib/electron",
         "angular2-toaster": "^11.0.1",
-        "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
         "node-ipc": "^9.1.4",
         "nord": "^0.2.1",
         "regedit": "^3.0.3",
@@ -23,7 +22,6 @@
       "devDependencies": {
         "@angular/compiler-cli": "^11.2.10",
         "@ngtools/webpack": "^11.2.10",
-        "@types/duo_web_sdk": "^2.7.0",
         "@types/node": "^14.14.43",
         "@types/node-ipc": "^9.1.4",
         "clean-webpack-plugin": "^3.0.0",
@@ -79,12 +77,14 @@
         "@angular/platform-browser-dynamic": "^11.2.11",
         "@angular/router": "^11.2.11",
         "@bitwarden/jslib-common": "file:../common",
+        "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
         "ngx-infinite-scroll": "10.0.1",
         "rxjs": "6.6.7",
         "tldjs": "^2.3.1",
         "zone.js": "0.11.4"
       },
       "devDependencies": {
+        "@types/duo_web_sdk": "^2.7.1",
         "rimraf": "^3.0.2",
         "typescript": "4.1.5"
       }
@@ -101,6 +101,7 @@
         "lunr": "^2.3.9",
         "node-forge": "^0.10.0",
         "papaparse": "^5.3.0",
+        "rxjs": "6.6.7",
         "tldjs": "^2.3.1",
         "zxcvbn": "^4.4.2"
       },
@@ -1020,9 +1021,9 @@
       "dev": true
     },
     "node_modules/@types/duo_web_sdk": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@types/duo_web_sdk/-/duo_web_sdk-2.7.0.tgz",
-      "integrity": "sha512-E8cRtor4+hYNVYZ/hk+0WoZtiGOWvxhX3UsJtNtVlDIk2d8dnbYX6wdhqBTwixPpw7ea3I8IS3BAK81GRXyLUQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@types/duo_web_sdk/-/duo_web_sdk-2.7.1.tgz",
+      "integrity": "sha512-DePanZjFww36yGSxXwC8B3AsjrrDuPxEcufeh4gTqVsUMpCYByxjX4PERiYZdW0typzKSt9E4I14PPp+PrSIQA==",
       "dev": true
     },
     "node_modules/@types/fs-extra": {
@@ -17011,6 +17012,8 @@
         "@angular/platform-browser-dynamic": "^11.2.11",
         "@angular/router": "^11.2.11",
         "@bitwarden/jslib-common": "file:../common",
+        "@types/duo_web_sdk": "^2.7.1",
+        "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
         "ngx-infinite-scroll": "10.0.1",
         "rimraf": "^3.0.2",
         "rxjs": "6.6.7",
@@ -17036,6 +17039,7 @@
         "node-forge": "^0.10.0",
         "papaparse": "^5.3.0",
         "rimraf": "^3.0.2",
+        "rxjs": "6.6.7",
         "tldjs": "^2.3.1",
         "typescript": "4.1.5",
         "zxcvbn": "^4.4.2"
@@ -17372,9 +17376,9 @@
       "dev": true
     },
     "@types/duo_web_sdk": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@types/duo_web_sdk/-/duo_web_sdk-2.7.0.tgz",
-      "integrity": "sha512-E8cRtor4+hYNVYZ/hk+0WoZtiGOWvxhX3UsJtNtVlDIk2d8dnbYX6wdhqBTwixPpw7ea3I8IS3BAK81GRXyLUQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@types/duo_web_sdk/-/duo_web_sdk-2.7.1.tgz",
+      "integrity": "sha512-DePanZjFww36yGSxXwC8B3AsjrrDuPxEcufeh4gTqVsUMpCYByxjX4PERiYZdW0typzKSt9E4I14PPp+PrSIQA==",
       "dev": true
     },
     "@types/fs-extra": {

--- a/package.json
+++ b/package.json
@@ -252,7 +252,6 @@
   "devDependencies": {
     "@angular/compiler-cli": "^11.2.10",
     "@ngtools/webpack": "^11.2.10",
-    "@types/duo_web_sdk": "^2.7.0",
     "@types/node": "^14.14.43",
     "@types/node-ipc": "^9.1.4",
     "clean-webpack-plugin": "^3.0.0",
@@ -293,7 +292,6 @@
     "@bitwarden/jslib-common": "file:jslib/common",
     "@bitwarden/jslib-electron": "file:jslib/electron",
     "angular2-toaster": "^11.0.1",
-    "duo_web_sdk": "git+https://github.com/duosecurity/duo_web_sdk.git",
     "node-ipc": "^9.1.4",
     "nord": "^0.2.1",
     "regedit": "^3.0.3",


### PR DESCRIPTION
## Objective
With bitwarden/jslib#441 I added `duo_web_sdk` as a dependency to `jslib/angular`. As jslib/angular is a dependency of this repo, it will pull in it's sub-dependencies of needed. Hence `duo_web_sdk` will still be available.

## Code Changes
- **package.json**:  Removed dev-dependency `@types/duo_web_sdk` and git link to `duo_web_sdk`
- **package.lock.json**: Changes after running `npm i`
- **jslib**: Updated submodule to current master