### PR TITLE
Set iframe allow on window load

### DIFF
--- a/src/app/accounts/two-factor.component.html
+++ b/src/app/accounts/two-factor.component.html
@@ -36,7 +36,7 @@
         </ng-container>
         <ng-container *ngIf="selectedProviderType === providerType.WebAuthn">
             <div id="web-authn-frame">
-                <iframe id="webauthn_iframe"></iframe>
+                <iframe id="webauthn_iframe" [allow]="webAuthnAllow"></iframe>
             </div>
             <div class="box first">
                 <div class="box-content">


### PR DESCRIPTION
# Overview

Chrome seems to balk at this attribute being added after the fact. It may be a race condition or an intentional block, but adding to the template fixes our missing allow attribute problem.

>Note: this will be cherry picked to `rc`