### PR TITLE
Close proxy application when stdin is closed

### DIFF
--- a/src/proxy/nativemessage.ts
+++ b/src/proxy/nativemessage.ts
@@ -89,5 +89,9 @@ export default class NativeMessage {
                 console.error(e);
             }
         });
+
+        process.stdin.on('end', () => {
+            process.exit(0);
+        });
     }
 }


### PR DESCRIPTION
## Objective
When closing Microsoft Edge the native messaging proxy application would sometimes continue running in the background until the Bitwarden Desktop application is closed. To avoid this I've added an event listener which terminates the application when stdin is closed.

### Testing Considerations
Verify native messaging still works, ensure all Microsoft Edge processes are closed when closing Edge.

Resolves https://github.com/bitwarden/desktop/issues/1016