### PR TITLE
Fix broken link to open Edge extension store from help menu

### DIFF
--- a/src/main/menu.main.ts
+++ b/src/main/menu.main.ts
@@ -296,8 +296,8 @@ export class MenuMain extends BaseMenu {
                     {
                         label: 'Edge',
                         click: () => {
-                            shell.openExternal('https://www.microsoft.com/store/p/' +
-                                'bitwarden-free-password-manager/9p6kxl0svnnl');
+                            shell.openExternal('https://microsoftedge.microsoft.com/addons/' +
+                                'detail/jbkfoedolllekgbhcbcoahefnbanhhlh');
                         },
                     },
                     {


### PR DESCRIPTION
The link in the help menu to install the extension from the Edge Store was broken. 

![image](https://user-images.githubusercontent.com/2670567/129768701-6d1ddc1d-ef49-45eb-b33e-c9526dda5b40.png)

Took the link to the Edge Store from https://bitwarden.com/download/ and replaced it