### PR TITLE
Added more suported browsers to the Chrome Webstore link in help menu

### DIFF
--- a/src/main/menu.main.ts
+++ b/src/main/menu.main.ts
@@ -273,7 +273,7 @@ export class MenuMain extends BaseMenu {
                 label: this.main.i18nService.t('getBrowserExtension'),
                 submenu: [
                     {
-                        label: 'Chrome',
+                        label: 'Chrome / Brave / Vivaldi / Tor Browser',
                         click: () => {
                             shell.openExternal('https://chrome.google.com/webstore/detail/' +
                                 'bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb');


### PR DESCRIPTION
Added Brave, Vivaldi and Tor Browser to the install extension menu in help menu


![image](https://user-images.githubusercontent.com/2670567/129769819-620e6853-6d23-4ecc-ad5f-27b8c7e9ffc8.png)


Closes #352 

