### PR TITLE
Added a comment to keep locale en as fallback in I18nService

### DIFF
--- a/src/services/i18n.service.ts
+++ b/src/services/i18n.service.ts
@@ -12,6 +12,7 @@ export class I18nService extends BaseI18nService {
             return Promise.resolve(locales);
         });
 
+        // Please leave 'en' where it is, as it's our fallback language in case no translation can be found
         this.supportedTranslationLocales = [
             'en', 'af', 'az', 'be', 'bg', 'bn', 'ca', 'cs', 'da', 'de', 'el', 'en-GB', 'en-IN', 'es', 'et', 'fa', 'fi', 'fr', 'he', 'hr', 'hu', 'id',
             'it', 'ja', 'kn', 'ko', 'lv', 'me', 'ml', 'nb', 'nl', 'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'sr', 'sv', 'th', 'tr', 'uk',


### PR DESCRIPTION
With #988 the AZ language was added. In this case the position of 'en' was kept. 

See https://github.com/bitwarden/browser/pull/1949 or https://github.com/bitwarden/web/pull/1079

This is important as it is used as our fallback language in case we can't offer a translation for the selected browser/system locale.

I've added the same comment included in https://github.com/bitwarden/web/pull/1140 and https://github.com/bitwarden/browser/pull/2026
 