### PR TITLE
[SSO/Auto Enroll] Set Password banner

### DIFF
--- a/src/app/accounts/set-password.component.html
+++ b/src/app/accounts/set-password.component.html
@@ -9,6 +9,10 @@
         <div *ngIf="!syncLoading">
             <div class="box">
                 <app-callout type="tip">{{'ssoCompleteRegistration' | i18n}}</app-callout>
+                <app-callout type="warning" title="{{'resetPasswordPolicyAutoEnroll' | i18n}}"
+                    *ngIf="resetPassswordAutoEnroll">
+                    {{'resetPasswordAutoEnrollInviteWarning' | i18n}}
+                </app-callout>
                 <app-callout type="info" [enforcedPolicyOptions]="enforcedPolicyOptions" *ngIf="enforcedPolicyOptions">
                 </app-callout>
             </div>

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1702,5 +1702,11 @@
   },
   "updateMasterPasswordWarning": {
     "message": "Your Master Password was recently changed by an administrator in your organization. In order to access the vault, you must update it now. Proceeding will log you out of your current session, requiring you to log back in. Active sessions on other devices may continue to remain active for up to one hour."
+  },
+  "resetPasswordPolicyAutoEnroll": {
+    "message": "Automatic Enrollment"
+  },
+  "resetPasswordAutoEnrollInviteWarning": {
+    "message": "This organization has an enterprise policy that will automatically enroll you in password reset. Enrollment will allow organization administrators to change your master password."
   }
 }


### PR DESCRIPTION
## Objective
> Add callout banner during SSO Set password flow when a user will be automatically enrolled in Reset Password program.

## Code Changes
- **set-password.component.html**: Added `callout` banner with information regarding auto enrollment
- **messages.json**: Added new strings for `callout`

## Screenshot
![desktop-sso-auto-enroll](https://user-images.githubusercontent.com/26154748/131705449-3985133c-c280-451f-9235-c30cce3b9e64.png)

## Prereqs
- [jslib: [SSO] Set password auto enroll update](https://github.com/bitwarden/jslib/pull/472)