### PR TITLE
Pinning ast version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
 
           git clone https://github.com/vcsjones/AzureSignTool.git
           cd AzureSignTool
-          $pinned_short_commit = $AST_PINNED_COMMIT[0..9] -join ""
+          $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
           $ast_version = "0.0.0-g$pinned_short_commit"
           
           #git clone https://github.com/joseph-flinn/AzureSignTool.git

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,16 +97,8 @@ jobs:
           SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.ast-test-cert-name }}
         run: |
           Set-Content -Path test.exe -Value "this is a test"
-          azuresigntool sign --verbose `
-            -kvu $SIGNING_VAULT_URL `
-            -kvi $SIGNING_CLIENT_ID `
-            -kvt $SIGNING_TENANT_ID `
-            -kvs $SIGNING_CLIENT_SECRET `
-            -kvc $SIGNING_CERT_NAME `
-            -fd sha1 `
-            -du https://bitwarden.com `
-            -tr http://timestamp.digicert.com `
-            test.exe
+          azuresigntool sign --help
+          azuresigntool sign -v -kvu $env:SIGNING_VAULT_URL -kvi $env:SIGNING_CLIENT_ID -kvt $env:SIGNING_TENANT_ID -kvs $env:SIGNING_CLIENT_SECRET -kvc $env:SIGNING_CERT_NAME -fd sha1 -du https://bitwarden.com -tr http://timestamp.digicert.com test.exe
 
 
   cloc:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Install AST
         shell: pwsh
         env:
-          AST_PINNED_COMMIT: "a67eca560bf95cd765579721f2787189c75e96ae"
+          AST_PINNED_COMMIT: "02845a3b631ea24852e72873b7a422e46d0bbae3"
         run: |
           cd $HOME
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,13 @@ jobs:
           node-version: '14'
 
       - name: Login to Azure
+        if: false
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
         with:
           creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
 
       - name: Retrieve secrets
+        if: false
         id: retrieve-secrets
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           git clone https://github.com/joseph-flinn/AzureSignTool.git
           cd AzureSignTool
           $pinned_short_commit = $(git rev-parse HEAD)[0..9] -join ""
-          $ast_version = "0.0.0-g$latest_head"
+          $ast_version = "0.0.0-g$pinned_short_commit"
 
           Write-Host "--------"
           Write-Host "pinned git commit - $AST_PINNED_COMMIT"
@@ -78,6 +78,7 @@ jobs:
           SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-tenant-id }}
           SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.ast-test-client-secret }}
           SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.ast-test-cert-name }}
+        shell: pwsh
         run: |
           Set-Content -Path test.exe -Value "this is a test"
           azuresigntool sign --help

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,8 +241,8 @@ jobs:
           cd $HOME
 
           git clone https://github.com/vcsjones/AzureSignTool.git
-          git switch --detach $env:AST_PINNED_COMMIT
           cd AzureSignTool
+          git switch --detach $env:AST_PINNED_COMMIT
           $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
           $ast_version = "0.0.0-g$pinned_short_commit"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,28 +42,21 @@ jobs:
       - name: Install AST
         shell: pwsh
         env:
-          #AST_PINNED_COMMIT: "ce87e84a58dff318f62ffe5177bf3e179d815108"
-          AST_PINNED_COMMIT: "latest"
+          AST_PINNED_COMMIT: "ce87e84a58dff318f62ffe5177bf3e179d815108"
         run: |
           cd $HOME
 
           #git clone https://github.com/vcsjones/AzureSignTool.git
           #cd AzureSignTool
+          #$pinned_short_commit = $AST_PINNED_COMMIT[0..9] -join ""
+          #$ast_version = "0.0.0-g$pinned_short_commit"
           
           git clone https://github.com/joseph-flinn/AzureSignTool.git
           cd AzureSignTool
+          $pinned_short_commit = $(git rev-parse HEAD)[0..9] -join ""
+          $ast_version = "0.0.0-g$latest_head"
 
           Write-Host "--------"
-          if ( $AST_PINNED_COMMIT -eq "latest") {
-            Write-Host "using latest commit"
-            $pinned_short_commit = $(git rev-parse HEAD)[0..9] -join ""
-            $ast_version = "0.0.0-g$latest_head"
-          }
-          else {
-            $pinned_short_commit = $AST_PINNED_COMMIT[0..9] -join ""
-            $ast_version = "0.0.0-g$pinned_short_commit"
-          }
-
           Write-Host "pinned git commit - $AST_PINNED_COMMIT"
           Write-Host "pinned short git commit - $pinned_short_commit"
           Write-Host "PACKAGE VERSION TO BUILD - $ast_version"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,13 +191,14 @@ jobs:
             -fd sha1 \
             -du https://bitwarden.com \
             -tr http://timestamp.digicert.com \
-            test.exe,
+            test.exe
         env:
           SIGNING_VAULT_URL: ${{ secrets.SIGNING_VAULT_URL }}
           SIGNING_CLIENT_ID: ${{ secrets.SIGNING_CLIENT_ID }}
           SIGNING_TENANT_ID: ${{ secrets.SIGNING_TENANT_ID }}
           SIGNING_CLIENT_SECRET: ${{ secrets.SIGNING_CLIENT_SECRET }}
           SIGNING_CERT_NAME: ${{ secrets.SIGNING_CERT_NAME }}
+
 
   windows:
     name: Windows Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
 
   windows:
     name: Windows Build
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -125,7 +125,7 @@ jobs:
       - name: Set up dotnet
         uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
         with:
-          dotnet-version: "3.1.x"
+          dotnet-version: "3.1.18"
 
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea  # v2.1.5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,7 @@ jobs:
           keyvault: "bitwarden-qa-kv"
           secrets: "ast-test-client-id,
                     ast-test-client-secret,
-                    ast-test-tenant-id,
-                    ast-test-vault-url,
-                    ast-test-cert-name"
+                    ast-test-tenant-id"
 
       - name: Cache npm
         id: npm-cache
@@ -87,14 +85,19 @@ jobs:
 
       - name: Test Sign
         env:
-          SIGNING_VAULT_URL: ${{ steps.retrieve-secrets.outputs.ast-test-vault-url }}
-          SIGNING_CLIENT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-client-id}}
-          SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-tenant-id }}
-          SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.ast-test-client-secret }}
-          SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.ast-test-cert-name }}
+          SIGNING_VAULT_URL: ${{ secrets.SIGNING_VAULT_URL }}
+          SIGNING_CLIENT_ID: ${{ secrets.SIGNING_CLIENT_ID }}
+          SIGNING_TENANT_ID: ${{ secrets.SIGNING_TENANT_ID }}
+          SIGNING_CLIENT_SECRET: ${{ secrets.SIGNING_CLIENT_SECRET }}
+          SIGNING_CERT_NAME: ${{ secrets.SIGNING_CERT_NAME }}
+          #SIGNING_VAULT_URL: ${{ steps.retrieve-secrets.outputs.ast-test-vault-url }}
+          #SIGNING_CLIENT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-client-id}}
+          #SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-tenant-id }}
+          #SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.ast-test-client-secret }}
+          #SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.ast-test-cert-name }}
         run: |
           Set-Content -Path test.exe -Value "this is a test"
-          azuresigntool sign `
+          azuresigntool sign --verbose `
             -kvu $SIGNING_VAULT_URL `
             -kvi $SIGNING_CLIENT_ID `
             -kvt $SIGNING_TENANT_ID `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
 
           git clone https://github.com/vcsjones/AzureSignTool.git
           cd AzureSignTool
+          git switch --detach $env:AST_PINNED_COMMIT
           $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
           $ast_version = "0.0.0-g$pinned_short_commit"
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,11 +25,6 @@ jobs:
         with:
           dotnet-version: "2.1.x"
 
-      - name: Set up Node
-        uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea  # v2.1.5
-        with:
-          node-version: '14'
-
       - name: Login to Azure
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
         with:
@@ -43,23 +38,6 @@ jobs:
           secrets: "ast-test-client-id,
                     ast-test-client-secret,
                     ast-test-tenant-id"
-
-      - name: Cache npm
-        id: npm-cache
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353  # v2.1.6
-        with:
-          path: '%AppData%/npm-cache'
-          key: ${{ runner.os }}-${{ github.run_id }}-npm-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Set Node options
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        shell: pwsh
-
-      - name: Update NPM
-        run: |
-          npm install -g npm@7
-          npm install -g node-gyp
-          node-gyp install $(node -v)
 
       - name: Install AST
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cloc:
     name: CLOC
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -26,7 +26,7 @@ jobs:
 
   linux:
     name: Linux Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -247,7 +247,7 @@ jobs:
 
   macos-build:
     name: MacOS Build
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -348,7 +348,7 @@ jobs:
 
   macos-package-github:
     name: MacOS Package GitHub Release Assets
-    runs-on: macos-latest
+    runs-on: macos-11
     needs: macos-build
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
@@ -478,7 +478,7 @@ jobs:
 
   macos-package-mas:
     name: MacOS Package Prod Release Asset
-    runs-on: macos-latest
+    runs-on: macos-11
     needs: macos-build
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
@@ -604,7 +604,7 @@ jobs:
   macos-package-dev:
     name: MacOS Package Dev Release Asset
     if: false  # We need to look into how code signing works for dev
-    runs-on: macos-latest
+    runs-on: macos-11
     needs: macos-build
     steps:
       - name: Checkout repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
           node-gyp install $(node -v)
 
       - name: Install AST
-        uses: bitwarden/gh-actions/install-ast@1fda0b3e691f96efa10dd0729795375f6c65a096
+        uses: bitwarden/gh-actions/install-ast@790744f948ff32e13cb61c17243e763dc3aebad7
 
       - name: Set up environment
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Install AST
         shell: pwsh
         env:
-          AST_PINNED_COMMIT: "ce87e84a58dff318f62ffe5177bf3e179d815108"
+          AST_PINNED_COMMIT: "a67eca560bf95cd765579721f2787189c75e96ae"
         run: |
           cd $HOME
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
           node-gyp install $(node -v)
 
       - name: Install AST
-        uses: bitwarden/gh-actions@1fda0b3e691f96efa10dd0729795375f6c65a096
+        uses: bitwarden/gh-actions/install-ast@1fda0b3e691f96efa10dd0729795375f6c65a096
 
       - name: Set up environment
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -247,7 +247,6 @@ jobs:
 
   macos-build:
     name: MacOS Build
-    if: false
     runs-on: macos-latest
     steps:
       - name: Checkout repo
@@ -351,8 +350,7 @@ jobs:
     name: MacOS Package GitHub Release Assets
     runs-on: macos-latest
     needs: macos-build
-    if: false
-    #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -482,8 +480,7 @@ jobs:
     name: MacOS Package Prod Release Asset
     runs-on: macos-latest
     needs: macos-build
-    if: false
-    #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
       - name: Set up dotnet
         uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
         with:
-          dotnet-version: "3.1.18"
+          dotnet-version: "3.1.x"
 
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea  # v2.1.5
@@ -152,7 +152,7 @@ jobs:
       - name: Install AST
         shell: pwsh
         env:
-          AST_PINNED_COMMIT: "a67eca560bf95cd765579721f2787189c75e96ae"
+          AST_PINNED_COMMIT: "ce87e84a58dff318f62ffe5177bf3e179d815108"
         run: |
           cd $HOME
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   cloc:
     name: CLOC
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -116,8 +117,91 @@ jobs:
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-x86_64.AppImage
           if-no-files-found: error
 
+
+  test-ast:
+    name: Test AST
+    runs-on: windows-2019
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
+
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
+        with:
+          dotnet-version: "3.1.x"
+
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
+        with:
+          dotnet-version: "2.1.x"
+
+      - name: Set up Node
+        uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea  # v2.1.5
+        with:
+          node-version: '14'
+
+      - name: Cache npm
+        id: npm-cache
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353  # v2.1.6
+        with:
+          path: '%AppData%/npm-cache'
+          key: ${{ runner.os }}-${{ github.run_id }}-npm-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Set Node options
+        run: echo "NODE_OPTIONS=--max_old_space_size=4096" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: pwsh
+
+      - name: Update NPM
+        run: |
+          npm install -g npm@7
+          npm install -g node-gyp
+          node-gyp install $(node -v)
+
+      - name: Install AST
+        shell: pwsh
+        env:
+          AST_PINNED_COMMIT: "02845a3b631ea24852e72873b7a422e46d0bbae3"
+        run: |
+          cd $HOME
+
+          git clone https://github.com/vcsjones/AzureSignTool.git
+          cd AzureSignTool
+          $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
+          $ast_version = "0.0.0-g$pinned_short_commit"
+
+          Write-Host "--------"
+          Write-Host "pinned git commit - $env:AST_PINNED_COMMIT"
+          Write-Host "pinned short git commit - $pinned_short_commit"
+          Write-Host "PACKAGE VERSION TO BUILD - $ast_version"
+          Write-Host "--------"
+
+          dotnet restore
+          dotnet pack --output ./nupkg
+          dotnet tool install --global --ignore-failed-sources --add-source ./nupkg --version $ast_version azuresigntool
+
+      - name: Test Sign
+        run: |
+          Set-Content -Path test.exe -Value "this is a test"
+          azuresigntool sign \
+            -kvu $SIGNING_VAULT_URL \
+            -kvi $SIGNING_CLIENT_ID \
+            -kvt $SIGNING_TENANT_ID \
+            -kvs $SIGNING_CLIENT_SECRET \
+            -kvc $SIGNING_CERT_NAME \
+            -fd sha1 \
+            -du https://bitwarden.com \
+            -tr http://timestamp.digicert.com \
+            test.exe,
+        env:
+          SIGNING_VAULT_URL: ${{ secrets.SIGNING_VAULT_URL }}
+          SIGNING_CLIENT_ID: ${{ secrets.SIGNING_CLIENT_ID }}
+          SIGNING_TENANT_ID: ${{ secrets.SIGNING_TENANT_ID }}
+          SIGNING_CLIENT_SECRET: ${{ secrets.SIGNING_CLIENT_SECRET }}
+          SIGNING_CERT_NAME: ${{ secrets.SIGNING_CERT_NAME }}
+
   windows:
     name: Windows Build
+    if: false
     runs-on: windows-2019
     steps:
       - name: Checkout repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,6 @@ jobs:
 
   linux:
     name: Linux Build
-    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -177,9 +176,6 @@ jobs:
           dotnet pack --output ./nupkg
           dotnet tool install --global --ignore-failed-sources --add-source ./nupkg --version $ast_version azuresigntool
 
-      - name: Test AST
-        run: azuresigntool --help
-
       - name: Set up environment
         shell: pwsh
         run: |
@@ -278,7 +274,6 @@ jobs:
 
   macos-build:
     name: MacOS Build
-    if: false
     runs-on: macos-latest
     steps:
       - name: Checkout repo
@@ -382,8 +377,7 @@ jobs:
     name: MacOS Package GitHub Release Assets
     runs-on: macos-latest
     needs: macos-build
-    if: false 
-    #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -513,8 +507,7 @@ jobs:
     name: MacOS Package Prod Release Asset
     runs-on: macos-latest
     needs: macos-build
-    if: false
-    #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install AST
         shell: pwsh
         env:
-          AST_PINNED_COMMIT: "02845a3b631ea24852e72873b7a422e46d0bbae3"
+          AST_PINNED_COMMIT: "ce87e84a58dff318f62ffe5177bf3e179d815108"
         run: |
           cd $HOME
 
@@ -76,7 +76,7 @@ jobs:
         run: |
           Set-Content -Path test.exe -Value "this is a test"
           azuresigntool sign --help
-          azuresigntool sign -v -kvu $env:SIGNING_VAULT_URL -kvi $env:SIGNING_CLIENT_ID -kvs $env:SIGNING_CLIENT_SECRET -kvc $env:SIGNING_CERT_NAME -fd sha1 -du https://bitwarden.com -tr http://timestamp.digicert.com test.exe
+          azuresigntool sign -v -kvu $env:SIGNING_VAULT_URL -kvi $env:SIGNING_CLIENT_ID -kvt $env:SIGNING_TENANT_ID -kvs $env:SIGNING_CLIENT_SECRET -kvc $env:SIGNING_CERT_NAME -fd sha1 -du https://bitwarden.com -tr http://timestamp.digicert.com test.exe
 
 
   cloc:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,104 @@ on:
       - 'gh-pages'
 
 jobs:
+  test-ast:
+    name: Test AST
+    runs-on: windows-2019
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
+
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
+        with:
+          dotnet-version: "3.1.x"
+
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
+        with:
+          dotnet-version: "2.1.x"
+
+      - name: Set up Node
+        uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea  # v2.1.5
+        with:
+          node-version: '14'
+
+      - name: Login to Azure
+        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
+        with:
+          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+
+      - name: Retrieve secrets
+        id: retrieve-secrets
+        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
+        with:
+          keyvault: "bitwarden-qa-kv"
+          secrets: "ast-test-client-id,
+                    ast-test-client-secret,
+                    ast-test-tenant-id,
+                    ast-test-vault-url,
+                    ast-test-cert-name"
+
+      - name: Cache npm
+        id: npm-cache
+        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353  # v2.1.6
+        with:
+          path: '%AppData%/npm-cache'
+          key: ${{ runner.os }}-${{ github.run_id }}-npm-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Set Node options
+        run: echo "NODE_OPTIONS=--max_old_space_size=4096" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        shell: pwsh
+
+      - name: Update NPM
+        run: |
+          npm install -g npm@7
+          npm install -g node-gyp
+          node-gyp install $(node -v)
+
+      - name: Install AST
+        shell: pwsh
+        env:
+          AST_PINNED_COMMIT: "02845a3b631ea24852e72873b7a422e46d0bbae3"
+        run: |
+          cd $HOME
+
+          git clone https://github.com/vcsjones/AzureSignTool.git
+          cd AzureSignTool
+          $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
+          $ast_version = "0.0.0-g$pinned_short_commit"
+
+          Write-Host "--------"
+          Write-Host "pinned git commit - $env:AST_PINNED_COMMIT"
+          Write-Host "pinned short git commit - $pinned_short_commit"
+          Write-Host "PACKAGE VERSION TO BUILD - $ast_version"
+          Write-Host "--------"
+
+          dotnet restore
+          dotnet pack --output ./nupkg
+          dotnet tool install --global --ignore-failed-sources --add-source ./nupkg --version $ast_version azuresigntool
+
+      - name: Test Sign
+        env:
+          SIGNING_VAULT_URL: ${{ steps.retrieve-secrets.outputs.ast-test-vault-url }}
+          SIGNING_CLIENT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-client-id}}
+          SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-tenant-id }}
+          SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.ast-test-client-secret }}
+          SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.ast-test-cert-name }}
+        run: |
+          Set-Content -Path test.exe -Value "this is a test"
+          azuresigntool sign `
+            -kvu $SIGNING_VAULT_URL `
+            -kvi $SIGNING_CLIENT_ID `
+            -kvt $SIGNING_TENANT_ID `
+            -kvs $SIGNING_CLIENT_SECRET `
+            -kvc $SIGNING_CERT_NAME `
+            -fd sha1 `
+            -du https://bitwarden.com `
+            -tr http://timestamp.digicert.com `
+            test.exe
+
+
   cloc:
     name: CLOC
     if: false
@@ -23,6 +121,7 @@ jobs:
 
       - name: Print lines of code
         run: cloc --include-lang TypeScript,JavaScript,HTML,Sass,CSS --vcs git
+
 
   linux:
     name: Linux Build
@@ -116,88 +215,6 @@ jobs:
           name: Bitwarden-${{ env.PACKAGE_VERSION }}-x86_64.AppImage
           path: ./dist/Bitwarden-${{ env.PACKAGE_VERSION }}-x86_64.AppImage
           if-no-files-found: error
-
-
-  test-ast:
-    name: Test AST
-    runs-on: windows-2019
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
-
-      - name: Set up dotnet
-        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
-        with:
-          dotnet-version: "3.1.x"
-
-      - name: Set up dotnet
-        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
-        with:
-          dotnet-version: "2.1.x"
-
-      - name: Set up Node
-        uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea  # v2.1.5
-        with:
-          node-version: '14'
-
-      - name: Cache npm
-        id: npm-cache
-        uses: actions/cache@c64c572235d810460d0d6876e9c705ad5002b353  # v2.1.6
-        with:
-          path: '%AppData%/npm-cache'
-          key: ${{ runner.os }}-${{ github.run_id }}-npm-${{ hashFiles('**/package-lock.json') }}
-
-      - name: Set Node options
-        run: echo "NODE_OPTIONS=--max_old_space_size=4096" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        shell: pwsh
-
-      - name: Update NPM
-        run: |
-          npm install -g npm@7
-          npm install -g node-gyp
-          node-gyp install $(node -v)
-
-      - name: Install AST
-        shell: pwsh
-        env:
-          AST_PINNED_COMMIT: "02845a3b631ea24852e72873b7a422e46d0bbae3"
-        run: |
-          cd $HOME
-
-          git clone https://github.com/vcsjones/AzureSignTool.git
-          cd AzureSignTool
-          $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
-          $ast_version = "0.0.0-g$pinned_short_commit"
-
-          Write-Host "--------"
-          Write-Host "pinned git commit - $env:AST_PINNED_COMMIT"
-          Write-Host "pinned short git commit - $pinned_short_commit"
-          Write-Host "PACKAGE VERSION TO BUILD - $ast_version"
-          Write-Host "--------"
-
-          dotnet restore
-          dotnet pack --output ./nupkg
-          dotnet tool install --global --ignore-failed-sources --add-source ./nupkg --version $ast_version azuresigntool
-
-      - name: Test Sign
-        run: |
-          Set-Content -Path test.exe -Value "this is a test"
-          azuresigntool sign `
-            -kvu $SIGNING_VAULT_URL `
-            -kvi $SIGNING_CLIENT_ID `
-            -kvt $SIGNING_TENANT_ID `
-            -kvs $SIGNING_CLIENT_SECRET `
-            -kvc $SIGNING_CERT_NAME `
-            -fd sha1 `
-            -du https://bitwarden.com `
-            -tr http://timestamp.digicert.com `
-            test.exe
-        env:
-          SIGNING_VAULT_URL: ${{ secrets.SIGNING_VAULT_URL }}
-          SIGNING_CLIENT_ID: ${{ secrets.SIGNING_CLIENT_ID }}
-          SIGNING_TENANT_ID: ${{ secrets.SIGNING_TENANT_ID }}
-          SIGNING_CLIENT_SECRET: ${{ secrets.SIGNING_CLIENT_SECRET }}
-          SIGNING_CERT_NAME: ${{ secrets.SIGNING_CERT_NAME }}
 
 
   windows:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,89 +8,8 @@ on:
       - 'gh-pages'
 
 jobs:
-  test-ast:
-    name: Test AST
-    runs-on: windows-2019
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
-
-      - name: Set up dotnet 3.1.x
-        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
-        with:
-          dotnet-version: "3.1.x"
-
-      - name: Set up dotnet 2.1.x
-        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
-        with:
-          dotnet-version: "2.1.x"
-
-      - name: Login to Azure
-        uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
-        with:
-          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
-
-      - name: Retrieve secrets
-        id: retrieve-secrets
-        uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
-        with:
-          keyvault: "bitwarden-qa-kv"
-          secrets: "ast-test-client-id,
-                    ast-test-client-secret,
-                    ast-test-tenant-id,
-                    ast-test-vault-url,
-                    ast-test-cert-name"
-
-      - name: Install AST
-        shell: pwsh
-        env:
-          AST_PINNED_COMMIT: "ce87e84a58dff318f62ffe5177bf3e179d815108"
-        run: |
-          cd $HOME
-
-          git clone https://github.com/vcsjones/AzureSignTool.git
-          cd AzureSignTool
-          git switch --detach $env:AST_PINNED_COMMIT
-          $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
-          $ast_version = "0.0.0-g$pinned_short_commit"
-
-          Write-Host "--------"
-          Write-Host "pinned git commit - $AST_PINNED_COMMIT"
-          Write-Host "pinned short git commit - $pinned_short_commit"
-          Write-Host "PACKAGE VERSION TO BUILD - $ast_version"
-          Write-Host "--------"
-
-          dotnet restore
-          dotnet pack --output ./nupkg
-          dotnet tool install --global --ignore-failed-sources --add-source ./nupkg --version $ast_version azuresigntool
-
-      - name: Test Sign
-        env:
-          SIGNING_VAULT_URL: ${{ secrets.SIGNING_VAULT_URL }}
-          SIGNING_CLIENT_ID: ${{ secrets.SIGNING_CLIENT_ID }}
-          SIGNING_TENANT_ID: ${{ secrets.SIGNING_TENANT_ID }}
-          SIGNING_CLIENT_SECRET: ${{ secrets.SIGNING_CLIENT_SECRET }}
-          SIGNING_CERT_NAME: ${{ secrets.SIGNING_CERT_NAME }}
-          #SIGNING_VAULT_URL: ${{ steps.retrieve-secrets.outputs.ast-test-vault-url }}
-          #SIGNING_CLIENT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-client-id}}
-          #SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-tenant-id }}
-          #SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.ast-test-client-secret }}
-          #SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.ast-test-cert-name }}
-        shell: pwsh
-        run: |
-          Set-Content -Path test.exe -Value "this is a test"
-
-          Write-Host "Vault URL: $env:SIGNING_VAULT_URL"
-          Write-Host "Client ID: $env:SIGNING_CLIENT_ID"
-          Write-Host "Client Secret: $env:SIGNING_CLIENT_SECRET"
-          Write-Host "Tenant ID: $env:SIGNING_TENANT_ID"
-          Write-Host "Cert Name: $env:SIGNING_CERT_NAME"
-          azuresigntool sign -v -kvu $env:SIGNING_VAULT_URL -kvi $env:SIGNING_CLIENT_ID -kvt $env:SIGNING_TENANT_ID -kvs $env:SIGNING_CLIENT_SECRET -kvc $env:SIGNING_CERT_NAME -fd sha1 -du https://bitwarden.com -tr http://timestamp.digicert.com test.exe
-
-
   cloc:
     name: CLOC
-    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -107,7 +26,6 @@ jobs:
 
   linux:
     name: Linux Build
-    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -206,11 +124,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
 
-      - name: Set up dotnet
-        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
-        with:
-          dotnet-version: "3.1.x"
-
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea  # v2.1.5
         with:
@@ -234,27 +147,7 @@ jobs:
           node-gyp install $(node -v)
 
       - name: Install AST
-        shell: pwsh
-        env:
-          AST_PINNED_COMMIT: "ce87e84a58dff318f62ffe5177bf3e179d815108"
-        run: |
-          cd $HOME
-
-          git clone https://github.com/vcsjones/AzureSignTool.git
-          cd AzureSignTool
-          git switch --detach $env:AST_PINNED_COMMIT
-          $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
-          $ast_version = "0.0.0-g$pinned_short_commit"
-
-          Write-Host "--------"
-          Write-Host "pinned git commit - $env:AST_PINNED_COMMIT"
-          Write-Host "pinned short git commit - $pinned_short_commit"
-          Write-Host "PACKAGE VERSION TO BUILD - $ast_version"
-          Write-Host "--------"
-
-          dotnet restore
-          dotnet pack --output ./nupkg
-          dotnet tool install --global --ignore-failed-sources --add-source ./nupkg --version $ast_version azuresigntool
+        uses: bitwarden/gh-actions@1fda0b3e691f96efa10dd0729795375f6c65a096
 
       - name: Set up environment
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
 
           git clone https://github.com/vcsjones/AzureSignTool.git
           cd AzureSignTool
-          $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9]
+          $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
           $ast_version = "0.0.0-g$pinned_short_commit"
 
           Write-Host "--------"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,9 @@ jobs:
           keyvault: "bitwarden-qa-kv"
           secrets: "ast-test-client-id,
                     ast-test-client-secret,
-                    ast-test-tenant-id"
+                    ast-test-tenant-id,
+                    ast-test-vault-url,
+                    ast-test-cert-name"
 
       - name: Install AST
         shell: pwsh
@@ -81,7 +83,6 @@ jobs:
         shell: pwsh
         run: |
           Set-Content -Path test.exe -Value "this is a test"
-          azuresigntool sign --help
 
           Write-Host "Vault URL: $env:SIGNING_VAULT_URL"
           Write-Host "Client ID: $env:SIGNING_CLIENT_ID"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,18 +156,19 @@ jobs:
 
           git clone https://github.com/vcsjones/AzureSignTool.git
           cd AzureSignTool
-          $latest_head = $(git rev-parse HEAD)[0..9] -join ""
-          $latest_version = "0.0.0-g$latest_head"
+          $pinned_commit = $(git rev-parse HEAD)[0..9] -join ""
+          $pinned_short_commit = "$pinned_commit"[0..9]
+          $ast_version = "0.0.0-g$pinned_short_commit"
 
           Write-Host "--------"
-          Write-Host "git commit - $(git rev-parse HEAD)"
-          Write-Host "latest_head - $latest_head"
-          Write-Host "PACKAGE VERSION TO BUILD - $latest_version"
+          Write-Host "pinned git commit - $(git rev-parse HEAD)"
+          Write-Host "pinned short git commit - $pinned_short_commit"
+          Write-Host "PACKAGE VERSION TO BUILD - $ast_version"
           Write-Host "--------"
 
           dotnet restore
           dotnet pack --output ./nupkg
-          dotnet tool install --global --ignore-failed-sources --add-source ./nupkg --version $latest_version azuresigntool
+          dotnet tool install --global --ignore-failed-sources --add-source ./nupkg --version $ast_version azuresigntool
 
       - name: Set up environment
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
           node-gyp install $(node -v)
 
       - name: Install AST
-        uses: bitwarden/gh-actions/install-ast@790744f948ff32e13cb61c17243e763dc3aebad7
+        uses: bitwarden/gh-actions/install-ast@f135c42c8596cb535c5bcb7523c0b2eef89709ac
 
       - name: Set up environment
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,17 +151,18 @@ jobs:
 
       - name: Install AST
         shell: pwsh
+        env:
+          AST_PINNED_COMMIT: "a67eca560bf95cd765579721f2787189c75e96ae"
         run: |
           cd $HOME
 
           git clone https://github.com/vcsjones/AzureSignTool.git
           cd AzureSignTool
-          $pinned_commit = $(git rev-parse HEAD)[0..9] -join ""
-          $pinned_short_commit = "$pinned_commit"[0..9]
+          $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9]
           $ast_version = "0.0.0-g$pinned_short_commit"
 
           Write-Host "--------"
-          Write-Host "pinned git commit - $(git rev-parse HEAD)"
+          Write-Host "pinned git commit - $env:AST_PINNED_COMMIT"
           Write-Host "pinned short git commit - $pinned_short_commit"
           Write-Host "PACKAGE VERSION TO BUILD - $ast_version"
           Write-Host "--------"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,16 +70,16 @@ jobs:
 
       - name: Test Sign
         env:
-          #SIGNING_VAULT_URL: ${{ secrets.SIGNING_VAULT_URL }}
-          #SIGNING_CLIENT_ID: ${{ secrets.SIGNING_CLIENT_ID }}
-          #SIGNING_TENANT_ID: ${{ secrets.SIGNING_TENANT_ID }}
-          #SIGNING_CLIENT_SECRET: ${{ secrets.SIGNING_CLIENT_SECRET }}
-          #SIGNING_CERT_NAME: ${{ secrets.SIGNING_CERT_NAME }}
-          SIGNING_VAULT_URL: ${{ steps.retrieve-secrets.outputs.ast-test-vault-url }}
-          SIGNING_CLIENT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-client-id}}
-          SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-tenant-id }}
-          SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.ast-test-client-secret }}
-          SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.ast-test-cert-name }}
+          SIGNING_VAULT_URL: ${{ secrets.SIGNING_VAULT_URL }}
+          SIGNING_CLIENT_ID: ${{ secrets.SIGNING_CLIENT_ID }}
+          SIGNING_TENANT_ID: ${{ secrets.SIGNING_TENANT_ID }}
+          SIGNING_CLIENT_SECRET: ${{ secrets.SIGNING_CLIENT_SECRET }}
+          SIGNING_CERT_NAME: ${{ secrets.SIGNING_CERT_NAME }}
+          #SIGNING_VAULT_URL: ${{ steps.retrieve-secrets.outputs.ast-test-vault-url }}
+          #SIGNING_CLIENT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-client-id}}
+          #SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-tenant-id }}
+          #SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.ast-test-client-secret }}
+          #SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.ast-test-cert-name }}
         shell: pwsh
         run: |
           Set-Content -Path test.exe -Value "this is a test"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,13 @@ jobs:
         run: |
           Set-Content -Path test.exe -Value "this is a test"
           azuresigntool sign --help
-          azuresigntool sign -v -kvu $SIGNING_VAULT_URL -kvi $SIGNING_CLIENT_ID -kvt $SIGNING_TENANT_ID -kvs $SIGNING_CLIENT_SECRET -kvc $SIGNING_CERT_NAME -fd sha1 -du https://bitwarden.com -tr http://timestamp.digicert.com test.exe
+
+          Write-Host "Vault URL: $env:SIGNING_VAULT_URL"
+          Write-Host "Client ID: $env:SIGNING_CLIENT_ID"
+          Write-Host "Client Secret: $env:SIGNING_CLIENT_SECRET"
+          Write-Host "Tenant ID: $env:SIGNING_TENANT_ID"
+          Write-Host "Cert Name: $env:SIGNING_CERT_NAME"
+          azuresigntool sign -v -kvu $env:SIGNING_VAULT_URL -kvi $env:SIGNING_CLIENT_ID -kvt $env:SIGNING_TENANT_ID -kvs $env:SIGNING_CLIENT_SECRET -kvc $env:SIGNING_CERT_NAME -fd sha1 -du https://bitwarden.com -tr http://timestamp.digicert.com test.exe
 
 
   cloc:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,11 +217,6 @@ jobs:
         with:
           dotnet-version: "3.1.x"
 
-      - name: Set up dotnet
-        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
-        with:
-          dotnet-version: "2.1.x"
-
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea  # v2.1.5
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
 
-      - name: Set up dotnet
+      - name: Set up dotnet 3.1.x
         uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
         with:
           dotnet-version: "3.1.x"
 
-      - name: Set up dotnet
+      - name: Set up dotnet 2.1.x
         uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
         with:
           dotnet-version: "2.1.x"
@@ -31,13 +31,11 @@ jobs:
           node-version: '14'
 
       - name: Login to Azure
-        if: false
         uses: Azure/login@77f1b2e3fb80c0e8645114159d17008b8a2e475a
         with:
-          creds: ${{ secrets.AZURE_PROD_KV_CREDENTIALS }}
+          creds: ${{ secrets.AZURE_QA_KV_CREDENTIALS }}
 
       - name: Retrieve secrets
-        if: false
         id: retrieve-secrets
         uses: Azure/get-keyvault-secrets@80ccd3fafe5662407cc2e55f202ee34bfff8c403
         with:
@@ -87,16 +85,16 @@ jobs:
 
       - name: Test Sign
         env:
-          SIGNING_VAULT_URL: ${{ secrets.SIGNING_VAULT_URL }}
-          SIGNING_CLIENT_ID: ${{ secrets.SIGNING_CLIENT_ID }}
-          SIGNING_TENANT_ID: ${{ secrets.SIGNING_TENANT_ID }}
-          SIGNING_CLIENT_SECRET: ${{ secrets.SIGNING_CLIENT_SECRET }}
-          SIGNING_CERT_NAME: ${{ secrets.SIGNING_CERT_NAME }}
-          #SIGNING_VAULT_URL: ${{ steps.retrieve-secrets.outputs.ast-test-vault-url }}
-          #SIGNING_CLIENT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-client-id}}
-          #SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-tenant-id }}
-          #SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.ast-test-client-secret }}
-          #SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.ast-test-cert-name }}
+          #SIGNING_VAULT_URL: ${{ secrets.SIGNING_VAULT_URL }}
+          #SIGNING_CLIENT_ID: ${{ secrets.SIGNING_CLIENT_ID }}
+          #SIGNING_TENANT_ID: ${{ secrets.SIGNING_TENANT_ID }}
+          #SIGNING_CLIENT_SECRET: ${{ secrets.SIGNING_CLIENT_SECRET }}
+          #SIGNING_CERT_NAME: ${{ secrets.SIGNING_CERT_NAME }}
+          SIGNING_VAULT_URL: ${{ steps.retrieve-secrets.outputs.ast-test-vault-url }}
+          SIGNING_CLIENT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-client-id}}
+          SIGNING_TENANT_ID: ${{ steps.retrieve-secrets.outputs.ast-test-tenant-id }}
+          SIGNING_CLIENT_SECRET: ${{ steps.retrieve-secrets.outputs.ast-test-client-secret }}
+          SIGNING_CERT_NAME: ${{ steps.retrieve-secrets.outputs.ast-test-cert-name }}
         run: |
           Set-Content -Path test.exe -Value "this is a test"
           azuresigntool sign --verbose `

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test-ast:
+    if: false
     name: Test AST
     runs-on: windows-2019
     steps:
@@ -206,7 +207,6 @@ jobs:
 
   windows:
     name: Windows Build
-    if: false
     runs-on: windows-2019
     steps:
       - name: Checkout repo
@@ -247,11 +247,12 @@ jobs:
       - name: Install AST
         shell: pwsh
         env:
-          AST_PINNED_COMMIT: "02845a3b631ea24852e72873b7a422e46d0bbae3"
+          AST_PINNED_COMMIT: "ce87e84a58dff318f62ffe5177bf3e179d815108"
         run: |
           cd $HOME
 
           git clone https://github.com/vcsjones/AzureSignTool.git
+          git switch --detach $env:AST_PINNED_COMMIT
           cd AzureSignTool
           $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
           $ast_version = "0.0.0-g$pinned_short_commit"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           Set-Content -Path test.exe -Value "this is a test"
           azuresigntool sign --help
-          azuresigntool sign -v -kvu $env:SIGNING_VAULT_URL -kvi $env:SIGNING_CLIENT_ID -kvt $env:SIGNING_TENANT_ID -kvs $env:SIGNING_CLIENT_SECRET -kvc $env:SIGNING_CERT_NAME -fd sha1 -du https://bitwarden.com -tr http://timestamp.digicert.com test.exe
+          azuresigntool sign -v -kvu $env:SIGNING_VAULT_URL -kvi $env:SIGNING_CLIENT_ID -kvs $env:SIGNING_CLIENT_SECRET -kvc $env:SIGNING_CERT_NAME -fd sha1 -du https://bitwarden.com -tr http://timestamp.digicert.com test.exe
 
 
   cloc:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ on:
 
 jobs:
   test-ast:
-    if: false
     name: Test AST
     runs-on: windows-2019
     steps:
@@ -54,11 +53,6 @@ jobs:
           git switch --detach $env:AST_PINNED_COMMIT
           $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
           $ast_version = "0.0.0-g$pinned_short_commit"
-          
-          #git clone https://github.com/joseph-flinn/AzureSignTool.git
-          #cd AzureSignTool
-          #$pinned_short_commit = $(git rev-parse HEAD)[0..9] -join ""
-          #$ast_version = "0.0.0-g$pinned_short_commit"
 
           Write-Host "--------"
           Write-Host "pinned git commit - $AST_PINNED_COMMIT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
 
   linux:
     name: Linux Build
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -171,6 +172,9 @@ jobs:
           dotnet pack --output ./nupkg
           dotnet tool install --global --ignore-failed-sources --add-source ./nupkg --version $ast_version azuresigntool
 
+      - name: Test AST
+        run: azuresigntool --help
+
       - name: Set up environment
         shell: pwsh
         run: |
@@ -269,6 +273,7 @@ jobs:
 
   macos-build:
     name: MacOS Build
+    if: false
     runs-on: macos-latest
     steps:
       - name: Checkout repo
@@ -372,7 +377,8 @@ jobs:
     name: MacOS Package GitHub Release Assets
     runs-on: macos-latest
     needs: macos-build
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+    if: false 
+    #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -502,7 +508,8 @@ jobs:
     name: MacOS Package Prod Release Asset
     runs-on: macos-latest
     needs: macos-build
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+    if: false
+    #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,15 +182,15 @@ jobs:
       - name: Test Sign
         run: |
           Set-Content -Path test.exe -Value "this is a test"
-          azuresigntool sign \
-            -kvu $SIGNING_VAULT_URL \
-            -kvi $SIGNING_CLIENT_ID \
-            -kvt $SIGNING_TENANT_ID \
-            -kvs $SIGNING_CLIENT_SECRET \
-            -kvc $SIGNING_CERT_NAME \
-            -fd sha1 \
-            -du https://bitwarden.com \
-            -tr http://timestamp.digicert.com \
+          azuresigntool sign `
+            -kvu $SIGNING_VAULT_URL `
+            -kvi $SIGNING_CLIENT_ID `
+            -kvt $SIGNING_TENANT_ID `
+            -kvs $SIGNING_CLIENT_SECRET `
+            -kvc $SIGNING_CERT_NAME `
+            -fd sha1 `
+            -du https://bitwarden.com `
+            -tr http://timestamp.digicert.com `
             test.exe
         env:
           SIGNING_VAULT_URL: ${{ secrets.SIGNING_VAULT_URL }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
 
   linux:
     name: Linux Build
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
@@ -274,6 +275,7 @@ jobs:
 
   macos-build:
     name: MacOS Build
+    if: false
     runs-on: macos-latest
     steps:
       - name: Checkout repo
@@ -377,7 +379,8 @@ jobs:
     name: MacOS Package GitHub Release Assets
     runs-on: macos-latest
     needs: macos-build
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+    if: false
+    #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -507,7 +510,8 @@ jobs:
     name: MacOS Package Prod Release Asset
     runs-on: macos-latest
     needs: macos-build
-    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
+    if: false
+    #if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/rc'
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,17 +42,29 @@ jobs:
       - name: Install AST
         shell: pwsh
         env:
-          AST_PINNED_COMMIT: "ce87e84a58dff318f62ffe5177bf3e179d815108"
+          #AST_PINNED_COMMIT: "ce87e84a58dff318f62ffe5177bf3e179d815108"
+          AST_PINNED_COMMIT: "latest"
         run: |
           cd $HOME
 
-          git clone https://github.com/vcsjones/AzureSignTool.git
+          #git clone https://github.com/vcsjones/AzureSignTool.git
+          #cd AzureSignTool
+          
+          git clone https://github.com/joseph-flinn/AzureSignTool.git
           cd AzureSignTool
-          $pinned_short_commit = $env:AST_PINNED_COMMIT[0..9] -join ""
-          $ast_version = "0.0.0-g$pinned_short_commit"
 
           Write-Host "--------"
-          Write-Host "pinned git commit - $env:AST_PINNED_COMMIT"
+          if ( $AST_PINNED_COMMIT -eq "latest") {
+            Write-Host "using latest commit"
+            $pinned_short_commit = $(git rev-parse HEAD)[0..9] -join ""
+            $ast_version = "0.0.0-g$latest_head"
+          }
+          else {
+            $pinned_short_commit = $AST_PINNED_COMMIT[0..9] -join ""
+            $ast_version = "0.0.0-g$pinned_short_commit"
+          }
+
+          Write-Host "pinned git commit - $AST_PINNED_COMMIT"
           Write-Host "pinned short git commit - $pinned_short_commit"
           Write-Host "PACKAGE VERSION TO BUILD - $ast_version"
           Write-Host "--------"
@@ -76,7 +88,7 @@ jobs:
         run: |
           Set-Content -Path test.exe -Value "this is a test"
           azuresigntool sign --help
-          azuresigntool sign -v -kvu $env:SIGNING_VAULT_URL -kvi $env:SIGNING_CLIENT_ID -kvt $env:SIGNING_TENANT_ID -kvs $env:SIGNING_CLIENT_SECRET -kvc $env:SIGNING_CERT_NAME -fd sha1 -du https://bitwarden.com -tr http://timestamp.digicert.com test.exe
+          azuresigntool sign -v -kvu $SIGNING_VAULT_URL -kvi $SIGNING_CLIENT_ID -kvt $SIGNING_TENANT_ID -kvs $SIGNING_CLIENT_SECRET -kvc $SIGNING_CERT_NAME -fd sha1 -du https://bitwarden.com -tr http://timestamp.digicert.com test.exe
 
 
   cloc:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,6 +128,11 @@ jobs:
         with:
           dotnet-version: "3.1.x"
 
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
+        with:
+          dotnet-version: "2.1.x"
+
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea  # v2.1.5
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,15 +48,15 @@ jobs:
         run: |
           cd $HOME
 
-          #git clone https://github.com/vcsjones/AzureSignTool.git
-          #cd AzureSignTool
-          #$pinned_short_commit = $AST_PINNED_COMMIT[0..9] -join ""
-          #$ast_version = "0.0.0-g$pinned_short_commit"
-          
-          git clone https://github.com/joseph-flinn/AzureSignTool.git
+          git clone https://github.com/vcsjones/AzureSignTool.git
           cd AzureSignTool
-          $pinned_short_commit = $(git rev-parse HEAD)[0..9] -join ""
+          $pinned_short_commit = $AST_PINNED_COMMIT[0..9] -join ""
           $ast_version = "0.0.0-g$pinned_short_commit"
+          
+          #git clone https://github.com/joseph-flinn/AzureSignTool.git
+          #cd AzureSignTool
+          #$pinned_short_commit = $(git rev-parse HEAD)[0..9] -join ""
+          #$ast_version = "0.0.0-g$pinned_short_commit"
 
           Write-Host "--------"
           Write-Host "pinned git commit - $AST_PINNED_COMMIT"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       package_version: ${{ steps.create_tags.outputs.package_version }}
       tag_version: ${{ steps.create_tags.outputs.tag_version }}
@@ -45,7 +45,7 @@ jobs:
 
   snap:
     name: Deploy Snap
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.package_version }}
@@ -81,7 +81,7 @@ jobs:
 
   choco:
     name: Deploy Choco
-    runs-on: windows-latest
+    runs-on: windows-2019
     needs: setup
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.package_version }}
@@ -124,7 +124,7 @@ jobs:
 
   macos:
     name: Deploy MacOS
-    runs-on: macos-latest
+    runs-on: macos-11
     needs: setup
     env:
       _PKG_VERSION: ${{ needs.setup.outputs.package_version }}
@@ -153,7 +153,7 @@ jobs:
 
   auto-updater-deploy:
     name: Release auto-updater files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - setup
       - snap
@@ -178,7 +178,8 @@ jobs:
           #cat release.json
 
           RELEASE_UPLOAD_URL=$(cat release.json | jq -r ' .upload_url ' | cut -d { -f 1)
-          cat release.json | jq -rc ' .assets[] | select( .name | test("prerelease-latest.*[yml|json]")) | {name: .name,  url: .url, content_type: .content_type}' > release_assets.jsonl
+          cat release.json \
+            | jq -rc ' .assets[] | select( .name | test("prerelease-latest.*[yml|json]")) | {name: .name,  url: .url, content_type: .content_type}' > release_assets.jsonl
 
           echo "=====ASSETS====="
           echo Release Upload URL: $RELEASE_UPLOAD_URL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           node-gyp install $(node -v)
 
       - name: Install AST
-        uses: bitwarden/gh-actions/install-ast@1fda0b3e691f96efa10dd0729795375f6c65a096
+        uses: bitwarden/gh-actions/install-ast@790744f948ff32e13cb61c17243e763dc3aebad7
 
       - name: Set up environment
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,12 +123,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
 
-      - name: Set up dotnet
+      - name: Set up dotnet 3.1.x
         uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
         with:
           dotnet-version: "3.1.x"
 
-      - name: Set up dotnet
+      - name: Set up dotnet 2.1.x
         uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
         with:
           dotnet-version: "2.1.x"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   setup:
     name: Setup
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       release_upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
@@ -62,7 +62,7 @@ jobs:
 
   linux:
     name: Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: setup
     steps:
       - name: Checkout repo
@@ -117,7 +117,7 @@ jobs:
 
   windows-signed:
     name: Windows Signed
-    runs-on: windows-latest
+    runs-on: windows-2019
     needs: setup
     steps:
       - name: Checkout repo
@@ -209,7 +209,7 @@ jobs:
 
   windows-store:
     name: Windows Store
-    runs-on: windows-latest
+    runs-on: windows-2019
     needs: setup
     steps:
       - name: Checkout repo
@@ -294,7 +294,7 @@ jobs:
 
   macos:
     name: MacOS
-    runs-on: macos-latest
+    runs-on: macos-11
     needs: setup
     steps:
       - name: Checkout repo
@@ -415,7 +415,7 @@ jobs:
 
   update-release-assets:
     name: Update Release Assets
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - setup
       - linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           node-gyp install $(node -v)
 
       - name: Install AST
-        uses: bitwarden/gh-actions@1fda0b3e691f96efa10dd0729795375f6c65a096
+        uses: bitwarden/gh-actions/install-ast@1fda0b3e691f96efa10dd0729795375f6c65a096
 
       - name: Set up environment
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,7 +146,7 @@ jobs:
           node-gyp install $(node -v)
 
       - name: Install AST
-        uses: bitwarden/gh-actions/install-ast@790744f948ff32e13cb61c17243e763dc3aebad7
+        uses: bitwarden/gh-actions/install-ast@f135c42c8596cb535c5bcb7523c0b2eef89709ac
 
       - name: Set up environment
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,16 +123,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
 
-      - name: Set up dotnet 3.1.x
-        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
-        with:
-          dotnet-version: "3.1.x"
-
-      - name: Set up dotnet 2.1.x
-        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
-        with:
-          dotnet-version: "2.1.x"
-
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea  # v2.1.5
         with:
@@ -156,24 +146,7 @@ jobs:
           node-gyp install $(node -v)
 
       - name: Install AST
-        shell: pwsh
-        run: |
-          cd $HOME
-
-          git clone https://github.com/vcsjones/AzureSignTool.git
-          cd AzureSignTool
-          $latest_head = $(git rev-parse HEAD)[0..9] -join ""
-          $latest_version = "0.0.0-g$latest_head"
-
-          Write-Host "--------"
-          Write-Host "git commit - $(git rev-parse HEAD)"
-          Write-Host "latest_head - $latest_head"
-          Write-Host "PACKAGE VERSION TO BUILD - $latest_version"
-          Write-Host "--------"
-
-          dotnet restore
-          dotnet pack --output ./nupkg
-          dotnet tool install --global --ignore-failed-sources --add-source ./nupkg --version $latest_version azuresigntool
+        uses: bitwarden/gh-actions@1fda0b3e691f96efa10dd0729795375f6c65a096
 
       - name: Set up environment
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,11 @@ jobs:
         with:
           dotnet-version: "3.1.x"
 
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@a71d1eb2c86af85faa8c772c03fb365e377e45ea  # v1.8.0
+        with:
+          dotnet-version: "2.1.x"
+
       - name: Set up Node
         uses: actions/setup-node@46071b5c7a2e0c34e49c3cb8a0e792e86e18d5ea  # v2.1.5
         with:

--- a/sign.js
+++ b/sign.js
@@ -5,7 +5,7 @@ exports.default = async function(configuration) {
   ) {
     console.log(`[*] Signing file: ${configuration.path}`)
     require("child_process").execSync(
-      `azuresigntool sign ` +
+      `azuresigntool sign -v ` +
       `-kvu ${process.env.SIGNING_VAULT_URL} ` +
       `-kvi ${process.env.SIGNING_CLIENT_ID} ` +
       `-kvt ${process.env.SIGNING_TENANT_ID} ` +


### PR DESCRIPTION
## Summary

The recent AST update broke functionality. Pinning the version to decrease attack surface of supply chain attacks as well as maintain stability in the pipeline. This has been done with the custom GitHub composite Action found at [bitwarden/gh-actions/install-ast](https://github.com/bitwarden/gh-actions/install-ast)