### PR TITLE
Add Slack alerts for Build workflow failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Print lines of code
         run: cloc --include-lang TypeScript,JavaScript,HTML,Sass,CSS --vcs git
 
-      - name: TEST FAILURE
-        run: exit 1
-
 
   setup:
     name: Setup


### PR DESCRIPTION
This PR adds a notify action that will send out a Slack alert if any of the jobs fail in the `build` workflow.