### PR TITLE
Ensure safari extension is included in mas and not only darwin

### DIFF
--- a/scripts/after-sign.js
+++ b/scripts/after-sign.js
@@ -16,7 +16,6 @@ async function run(context) {
     const copyPlugIn = ['darwin', 'mas'].includes(context.electronPlatformName);
 
     if (copyPlugIn) {
-        console.log(context.packager.platformSpecificBuildOptions);
         // Copy Safari plugin to work-around https://github.com/electron-userland/electron-builder/issues/5552
         const plugIn = path.join(__dirname, '../PlugIns');
         if (fse.existsSync(plugIn)) {
@@ -26,6 +25,11 @@ async function run(context) {
             // Resign to sign safari extension
             if (context.electronPlatformName === 'mas') {
                 const masBuildOptions = deepAssign({}, context.packager.platformSpecificBuildOptions, context.packager.config.mas);
+                if (context.targets.some(e => e.name === 'mas-dev')) {
+                    deepAssign(masBuildOptions, {
+                        type: 'development',
+                    });
+                }
                 if (context.packager.packagerOptions.prepackaged == null) {
                     await context.packager.sign(appPath, context.appOutDir, masBuildOptions, context.arch);
                 }
@@ -35,7 +39,7 @@ async function run(context) {
         }
     }
 
-    if (copyPlugIn) {
+    if (macBuild) {
         console.log('### Notarizing ' + appPath);
         const appleId = process.env.APPLE_ID_USERNAME || process.env.APPLEID;
         const appleIdPassword = process.env.APPLE_ID_PASSWORD || `@keychain:AC_PASSWORD`;


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The upgrade of electron builder in #1088 changed how we include and sign the safari extension. Unfortunately when building for the mac app store the `electronPlatformName` is not `darwin` but `mas`. This resulted in the extension not being included in the desktop release.

I needed to also change from `signApp` to `sign` since we need to sign a MAS application, which required me to replicate some of the logic used to build the arguments.

## Code changes
* **scripts/after-sign.js**: Ensure `mas` runs the specific copy and re-sign of the safari extension.

## Testing requirements
Verify the GH release pipeline contains the `safari.appex` in `PlugIn` directory.

## Before you submit
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [x] This change has particular **deployment requirements** (notify the DevOps team)
