### PR TITLE
Fix Safari Extension checkout in Build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
     outputs:
       package_version: ${{ steps.retrieve-version.outputs.package_version }}
       build_number: ${{ steps.increment-version.outputs.build_number }}
+      safari_ref: ${{ steps.safari-ref.outputs.safari_ref }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -40,12 +41,26 @@ jobs:
           PKG_VERSION=$(jq -r .version src/package.json)
           echo "::set-output name=package_version::$PKG_VERSION"
 
-      - name: Increment version
+      - name: Increment Version
         id: increment-version
         run: |
           BUILD_NUMBER=$(expr 500 + $GITHUB_RUN_NUMBER)
           echo "Setting build number to $BUILD_NUMBER"
           echo "::set-output name=build_number::$BUILD_NUMBER"
+
+      - name: Get Safari Branch Ref
+        id: safari-ref
+        run: |
+          SAFARI_REF=master
+
+          if [ "$GITHUB_REF" = "hotfix" ]; then
+              SAFARI_REF=hotfix
+          elif [ "$GITHUB_REF" = "rc" ]; then
+              SAFARI_REF=rc
+          fi
+
+          echo "Setting Safari Extension ref to $SAFARI_REF"
+          echo "::set-output name=safari_ref::$SAFARI_REF"
 
 
   linux:
@@ -465,6 +480,7 @@ jobs:
         with:
           repository: 'bitwarden/browser'
           path: 'dist-safari/browser'
+          ref: ${{ needs.setup.outputs.safari_ref }}
 
       - name: Build Safari extension
         shell: pwsh
@@ -612,7 +628,7 @@ jobs:
         with:
           repository: 'bitwarden/browser'
           path: 'dist-safari/browser'
-          ref: ${{ github.ref }}
+          ref: ${{ needs.setup.outputs.safari_ref }}
 
       - name: Build Safari extension
         if: steps.safari-cache.outputs.cache-hit != 'true'
@@ -800,7 +816,7 @@ jobs:
         with:
           repository: 'bitwarden/browser'
           path: 'dist-safari/browser'
-          ref: ${{ github.ref }}
+          ref: ${{ needs.setup.outputs.safari_ref }}
 
       - name: Build Safari extension
         if: steps.safari-cache.outputs.cache-hit != 'true'
@@ -970,6 +986,7 @@ jobs:
         with:
           repository: 'bitwarden/browser'
           path: 'dist-safari/browser'
+          ref: ${{ needs.setup.outputs.safari_ref }}
 
       - name: Build Safari extension
         if: steps.safari-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR fixes our checkout steps in the `build` workflow where we checkout the Safari extension code.  It will checkout `rc` if the workflow is run on `rc`, `hotfix` if the workflow is run on `hotfix`, or finally will just use `master` for the Safari extension when the workflow is run on any other branch.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **build.yml:** Added a step in the `setup` job to set a variable for the correct branch to checkout for the Safari extension.  Changed the checkout steps for the Safari Extension to use the new variable.