### PR TITLE
Add Universal DMG Artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -817,8 +817,6 @@ jobs:
         env:
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/
-          SDK_DIR: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/
 
       - name: Upload .pkg artifact
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700  # v2.2.3
@@ -986,8 +984,6 @@ jobs:
         env:
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
-          SDKROOT: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/
-          SDK_DIR: /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk/
 
       - name: Zip masdev asset
         working-directory: ./dist/mas-dev-universal

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -326,7 +326,7 @@ jobs:
 
   macos-build:
     name: MacOS Build
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: setup
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
@@ -661,7 +661,7 @@ jobs:
 
   macos-package-mas:
     name: MacOS Package Prod Release Asset
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: [setup, macos-build]
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}
@@ -831,7 +831,7 @@ jobs:
   macos-package-dev:
     name: MacOS Package Dev Release Asset
     if: false  # We need to look into how code signing works for dev
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: [setup, macos-build]
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -473,7 +473,7 @@ jobs:
 
   macos-package-github:
     name: MacOS Package GitHub Release Assets
-    runs-on: macos-10.15
+    runs-on: macos-11
     needs: [setup, macos-build]
     env:
       _PACKAGE_VERSION: ${{ needs.setup.outputs.package_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -633,22 +633,22 @@ jobs:
       - name: Upload .zip artifact
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700  # v2.2.3
         with:
-          name: Bitwarden-${{ env._PACKAGE_VERSION }}-mac.zip
-          path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-mac.zip
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}-universal-mac.zip
+          path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-universal-mac.zip
           if-no-files-found: error
 
       - name: Upload .dmg artifact
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700  # v2.2.3
         with:
-          name: Bitwarden-${{ env._PACKAGE_VERSION }}.dmg
-          path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}.dmg
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}-universal.dmg
+          path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-universal.dmg
           if-no-files-found: error
 
       - name: Upload .dmg blockmap artifact
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700  # v2.2.3
         with:
-          name: Bitwarden-${{ env._PACKAGE_VERSION }}.dmg.blockmap
-          path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}.dmg.blockmap
+          name: Bitwarden-${{ env._PACKAGE_VERSION }}-universal.dmg.blockmap
+          path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-universal.dmg.blockmap
           if-no-files-found: error
 
       - name: Upload latest auto-update artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,9 +76,9 @@ jobs:
                       Bitwarden-${{ env.PKG_VERSION }}-arm64.nsis.7z,
                       bitwarden.${{ env.PKG_VERSION }}.nupkg,
                       latest.yml,
-                      Bitwarden-${{ env.PKG_VERSION }}-mac.zip,
-                      Bitwarden-${{ env.PKG_VERSION }}.dmg,
-                      Bitwarden-${{ env.PKG_VERSION }}.dmg.blockmap,
+                      Bitwarden-${{ env.PKG_VERSION }}-universal-mac.zip,
+                      Bitwarden-${{ env.PKG_VERSION }}-universal.dmg,
+                      Bitwarden-${{ env.PKG_VERSION }}-universal.dmg.blockmap,
                       latest-mac.yml,
                       Bitwarden-${{ env.PKG_VERSION }}-universal.pkg"
           commit: ${{ github.sha }}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "clean:l10n": "git push origin --delete l10n_master",
     "pack:dir": "npm run clean:dist && electron-builder --dir -p never",
     "pack:lin": "npm run clean:dist && electron-builder --linux --x64 -p never",
-    "pack:mac": "npm run clean:dist && electron-builder --mac -p never",
+    "pack:mac": "npm run clean:dist && electron-builder --mac --universal -p never",
     "pack:mac:arm64": "npm run clean:dist && electron-builder --mac --arm64 -p never",
     "pack:mac:mas": "npm run clean:dist && electron-builder --mac mas --universal -p never",
     "pack:mac:masdev": "npm run clean:dist && electron-builder --mac mas-dev --universal -p never",


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Adds a universal DMG artifact in order to run natively on ARM64.


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

* **package.json:** Adds the `--universal` flag in order to generate new DMG artifact that can run natively on `ARM64` arch.
* **build.yml:** Upgrade all runners to macOS 11. Use proper artifact name for `universal` DMG.
* **release.yml:** Change artifact name to upload `universal` DMG to GitHub release.