### PR TITLE
Enable TestFlight for MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,8 @@ jobs:
       package_version: ${{ steps.retrieve-version.outputs.package_version }}
       build_number: ${{ steps.increment-version.outputs.build_number }}
       safari_ref: ${{ steps.safari-ref.outputs.safari_ref }}
+      rc_branch_exists: ${{ steps.branch-check.outputs.rc_branch_exists }}
+      hotfix_branch_exists: ${{ steps.branch-check.outputs.hotfix_branch_exists }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
@@ -61,6 +63,21 @@ jobs:
 
           echo "Setting Safari Extension ref to $SAFARI_REF"
           echo "::set-output name=safari_ref::$SAFARI_REF"
+
+      - name: Check if special branches exist
+        id: branch-check
+        run: |
+          if [[ $(git ls-remote --heads origin rc) ]]; then
+            echo "::set-output name=rc_branch_exists::1"
+          else
+            echo "::set-output name=rc_branch_exists::0"
+          fi
+
+          if [[ $(git ls-remote --heads origin hotfix) ]]; then
+            echo "::set-output name=hotfix_branch_exists::1"
+          else
+            echo "::set-output name=hotfix_branch_exists::0"
+          fi
 
 
   linux:
@@ -215,9 +232,6 @@ jobs:
         run: npm run lint
 
       - name: Build & Sign (dev)
-        run: |
-          npm run build
-          npm run pack:win
         env:
           ELECTRON_BUILDER_SIGN: 1
           SIGNING_VAULT_URL: ${{ secrets.SIGNING_VAULT_URL }}
@@ -225,6 +239,9 @@ jobs:
           SIGNING_TENANT_ID: ${{ secrets.SIGNING_TENANT_ID }}
           SIGNING_CLIENT_SECRET: ${{ secrets.SIGNING_CLIENT_SECRET }}
           SIGNING_CERT_NAME: ${{ secrets.SIGNING_CERT_NAME }}
+        run: |
+          npm run build
+          npm run pack:win
 
       - name: Rename appx files for store
         shell: pwsh
@@ -640,11 +657,11 @@ jobs:
         run: ./scripts/safari-build.ps1 -copyonly
 
       - name: Build application (dist)
-        run: |
-          npm run pack:mac
         env:
           APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+        run: |
+          npm run pack:mac
 
       - name: Upload .zip artifact
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700  # v2.2.3
@@ -840,6 +857,18 @@ jobs:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-universal.pkg
           path: ./dist/mas-universal/Bitwarden-${{ env._PACKAGE_VERSION }}-universal.pkg
           if-no-files-found: error
+
+      - name: Deploy to TestFlight
+        env:
+          APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
+          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
+        if: |
+            (github.ref == 'refs/heads/master'
+              && needs.setup.outputs.rc_branch_exists == 0
+              && needs.setup.outputs.hotfix_branch_exists == 0)
+            || (github.ref == 'refs/heads/rc' && needs.setup.outputs.hotfix_branch_exists == 0)
+            || github.ref == 'refs/heads/hotfix'
+        run: npm run upload:mas
 
 
   macos-package-dev:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,32 +163,3 @@ jobs:
         run: |
           cd dist
           choco push
-
-
-  macos:
-    name: Deploy MacOS
-    runs-on: macos-10.15
-    needs: setup
-    env:
-      _PKG_VERSION: ${{ needs.setup.outputs.package_version }}
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f  # v2.3.4
-
-      - name: Make target directory
-        run: mkdir -p dist/mas-universal
-
-      - name: Download Mac artifact
-        uses: bitwarden/gh-actions/download-artifacts@23433be15ed6fd046ce12b6889c5184a8d9c8783
-        with:
-          workflow: build.yml
-          workflow_conclusion: success
-          branch: ${{ needs.setup.outputs.branch-name }}
-          artifacts: Bitwarden-${{ env._PKG_VERSION }}-universal.pkg
-          path: ./dist/mas-universal
-
-      - name: Deploy to App Store
-        run: npm run upload:mas
-        env:
-          APPLE_ID_USERNAME: ${{ secrets.APPLE_ID_USERNAME }}
-          APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Enable TestFlight for our Desktop MacOS app.


## Code changes
* **.github/workflows/build.yml:** Adds code to `setup` to do a special branch check for the MAS push. Adds in the MAS push 
* **.github/workflows/release.yml:** Removes the MAS push

## Testing requirements
I'm not sure exactly how TestFlight works. I've been told it is the exact same process as we are following today in the release pipeline, just enabling it for the different branches. When this PR is merged, we will need to make sure it is working off of `master`


## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
