### PR TITLE
Revert linux ARM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,13 +143,6 @@ jobs:
           path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-amd64.deb
           if-no-files-found: error
 
-      - name: Upload ARM64 .deb artifact
-        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700  # v2.2.3
-        with:
-          name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.deb
-          path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.deb
-          if-no-files-found: error
-
       - name: Upload .rpm artifact
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700  # v2.2.3
         with:
@@ -157,25 +150,11 @@ jobs:
           path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-x86_64.rpm
           if-no-files-found: error
 
-      - name: Upload ARM64 .rpm artifact
-        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700  # v2.2.3
-        with:
-          name: Bitwarden-${{ env._PACKAGE_VERSION }}-aarch64.rpm
-          path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-aarch64.rpm
-          if-no-files-found: error
-
       - name: Upload .freebsd artifact
         uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700  # v2.2.3
         with:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-x64.freebsd
           path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-x64.freebsd
-          if-no-files-found: error
-
-      - name: Upload ARM64 .freebsd artifact
-        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700  # v2.2.3
-        with:
-          name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.freebsd
-          path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.freebsd
           if-no-files-found: error
 
       - name: Upload .snap artifact
@@ -190,13 +169,6 @@ jobs:
         with:
           name: Bitwarden-${{ env._PACKAGE_VERSION }}-x86_64.AppImage
           path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-x86_64.AppImage
-          if-no-files-found: error
-
-      - name: Upload ARM64 .AppImage artifact
-        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700  # v2.2.3
-        with:
-          name: Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.AppImage
-          path: ./dist/Bitwarden-${{ env._PACKAGE_VERSION }}-arm64.AppImage
           if-no-files-found: error
 
       - name: Upload latest auto-update artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,14 +63,10 @@ jobs:
           PKG_VERSION: ${{ steps.retrieve-version.outputs.package_version }}
         with:
           artifacts: "Bitwarden-${{ env.PKG_VERSION }}-amd64.deb,
-                      Bitwarden-${{ env.PKG_VERSION }}-arm64.deb,
                       Bitwarden-${{ env.PKG_VERSION }}-x86_64.rpm,
-                      Bitwarden-${{ env.PKG_VERSION }}-aarch64.rpm,
                       Bitwarden-${{ env.PKG_VERSION }}-x64.freebsd,
-                      Bitwarden-${{ env.PKG_VERSION }}-arm64.freebsd,
                       bitwarden_${{ env.PKG_VERSION }}_amd64.snap,
                       Bitwarden-${{ env.PKG_VERSION }}-x86_64.AppImage,
-                      Bitwarden-${{ env.PKG_VERSION }}-arm64.AppImage,
                       latest-linux.yml,
                       Bitwarden-Portable-${{ env.PKG_VERSION }}.exe,
                       Bitwarden-Installer-${{ env.PKG_VERSION }}.exe,

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "clean:dist": "rimraf ./dist/*",
     "clean:l10n": "git push origin --delete l10n_master",
     "pack:dir": "npm run clean:dist && electron-builder --dir -p never",
-    "pack:lin": "npm run clean:dist && electron-builder --linux -p never",
+    "pack:lin": "npm run clean:dist && electron-builder --linux --x64 -p never",
     "pack:mac": "npm run clean:dist && electron-builder --mac --universal -p never",
     "pack:mac:arm64": "npm run clean:dist && electron-builder --mac --arm64 -p never",
     "pack:mac:mas": "npm run clean:dist && electron-builder --mac mas --universal -p never",
@@ -54,7 +54,7 @@
     "dist:mac:masdev": "npm run build && npm run pack:mac:masdev",
     "dist:win": "npm run build && npm run pack:win",
     "dist:win:ci": "npm run build && npm run pack:win:ci",
-    "publish:lin": "npm run build && npm run clean:dist && electron-builder --linux -p always",
+    "publish:lin": "npm run build && npm run clean:dist && electron-builder --linux --x64 -p always",
     "publish:mac": "npm run build && npm run clean:dist && electron-builder --mac -p always",
     "publish:mac:mas": "npm run dist:mac:mas && npm run upload:mas",
     "publish:win": "npm run build && npm run clean:dist && electron-builder --win --x64 --arm64 --ia32 -p always -c.win.certificateSubjectName=\"8bit Solutions LLC\"",
@@ -142,11 +142,11 @@
       "category": "Utility",
       "synopsis": "A secure and free password manager for all of your devices.",
       "target": [
-	      { "target": "deb", "arch": [ "x64", "arm64" ]},
-	      { "target": "freebsd", "arch": [ "x64", "arm64" ]},
-	      { "target": "rpm", "arch": [ "x64", "arm64" ]},
-	      { "target": "AppImage", "arch": [ "x64", "arm64" ]},
-	      { "target": "snap", "arch": [ "x64" ]}
+        "deb",
+        "freebsd",
+        "rpm",
+        "AppImage",
+        "snap"
       ],
       "desktop": {
         "Name": "Bitwarden",


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [x] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Revert the newly added Linux ARM build artifacts. 

While testing the artifacts, we discovered that none of them actually work. Cross-compiling from x86/amd64 to arm64 is not possible with electron ([BeeKeeper Studio article](https://www.beekeeperstudio.io/blog/electron-apps-for-arm-and-raspberry-pi) as reference).


## Code changes
* **.github/workflows/build.yml:** revert code
* **.github/workflows/release.yml:** revert code
* **package.json:** revert code


## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)