### PR TITLE
[Key Connector] Resolve not prompting to remove password 

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -273,7 +273,7 @@ export class AppComponent implements OnInit {
                         }
                         break;
                     case 'convertAccountToKeyConnector':
-                        this.keyConnectorService.setConvertAccountRequired(true);
+                        await this.keyConnectorService.setConvertAccountRequired(true);
                         this.router.navigate(['/remove-password']);
                         break;
                 }


### PR DESCRIPTION
## Type of change
- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Resolves an issue where the desktop application didn't correctly prompt to remove password after first unlock with key connector.

While resolving the issue in jslib, I noticed we don't await the storage operation. I added an `await` here just to be safe.

Depends on https://github.com/bitwarden/jslib/pull/558

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
