### PR TITLE
Replace toaster library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@bitwarden/jslib-angular": "file:jslib/angular",
         "@bitwarden/jslib-common": "file:jslib/common",
         "@bitwarden/jslib-electron": "file:jslib/electron",
-        "angular2-toaster": "^11.0.1",
+        "ngx-toastr": "^13.2.1",
         "node-ipc": "^9.1.4",
         "nord": "^0.2.1",
         "regedit": "^3.0.3",
@@ -1738,20 +1738,6 @@
       "dev": true,
       "peerDependencies": {
         "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/angular2-toaster": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/angular2-toaster/-/angular2-toaster-11.0.1.tgz",
-      "integrity": "sha512-IRXE5zujPMNOhckcp+Hk2n+UrKSrlAviz55wGvSd9ECrqsSRjgh148UEtgsqkcYQ8leKcybZ4d0lrueDuQofNA==",
-      "dependencies": {
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "^11.0.0",
-        "@angular/compiler": "^11.0.0",
-        "@angular/core": "^11.0.0",
-        "rxjs": "^6.5.3"
       }
     },
     "node_modules/ansi-align": {
@@ -8477,6 +8463,19 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/ngx-toastr": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-13.2.1.tgz",
+      "integrity": "sha512-UAzp7/xWK9IXA2LsOmhpaaIGCqscvJokoQpBNpAMrjEkDeSlFf8PWQAuQY795KW0mJb3qF9UG/s23nsXfMYKmg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": ">=10.0.0-0",
+        "@angular/core": ">=10.0.0-0",
+        "@angular/platform-browser": ">=10.0.0-0"
+      }
     },
     "node_modules/no-case": {
       "version": "3.0.4",
@@ -15472,14 +15471,6 @@
       "dev": true,
       "requires": {}
     },
-    "angular2-toaster": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/angular2-toaster/-/angular2-toaster-11.0.1.tgz",
-      "integrity": "sha512-IRXE5zujPMNOhckcp+Hk2n+UrKSrlAviz55wGvSd9ECrqsSRjgh148UEtgsqkcYQ8leKcybZ4d0lrueDuQofNA==",
-      "requires": {
-        "tslib": "^2.0.0"
-      }
-    },
     "ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -20731,6 +20722,14 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "ngx-toastr": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-13.2.1.tgz",
+      "integrity": "sha512-UAzp7/xWK9IXA2LsOmhpaaIGCqscvJokoQpBNpAMrjEkDeSlFf8PWQAuQY795KW0mJb3qF9UG/s23nsXfMYKmg==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
     },
     "no-case": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -285,7 +285,7 @@
     "@bitwarden/jslib-angular": "file:jslib/angular",
     "@bitwarden/jslib-common": "file:jslib/common",
     "@bitwarden/jslib-electron": "file:jslib/electron",
-    "angular2-toaster": "^11.0.1",
+    "ngx-toastr": "^13.2.1",
     "node-ipc": "^9.1.4",
     "nord": "^0.2.1",
     "regedit": "^3.0.3",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -79,10 +79,6 @@ export class AppComponent implements OnInit {
     @ViewChild('appPasswordGenerator', { read: ViewContainerRef, static: true })
         passwordGeneratorModalRef: ViewContainerRef;
 
-    toasterConfig: Partial<IndividualConfig> = {
-        closeButton: true,
-    };
-
     private lastActivity: number = null;
     private modal: ModalRef = null;
     private idleTimer: number = null;
@@ -423,7 +419,7 @@ export class AppComponent implements OnInit {
     private showToast(msg: any) {
         let message = '';
 
-        const options = Object.assign({}, this.toasterConfig);
+        const options: Partial<IndividualConfig> = {};
 
         if (typeof (msg.text) === 'string') {
             message = msg.text;

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -179,6 +179,7 @@ registerLocaleData(localeZhTw, 'zh-TW');
         BitwardenToastModule.forRoot({
             maxOpened: 5,
             autoDismiss: true,
+            closeButton: true,
         }),
         ScrollingModule,
         A11yModule,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,5 @@
 import 'zone.js/dist/zone';
 
-import { ToasterModule } from 'angular2-toaster';
-
 import { AppRoutingModule } from './app-routing.module';
 import { ServicesModule } from './services.module';
 
@@ -33,6 +31,7 @@ import { VaultTimeoutInputComponent } from './accounts/vault-timeout-input.compo
 
 import { CalloutComponent } from 'jslib-angular/components/callout.component';
 import { IconComponent } from 'jslib-angular/components/icon.component';
+import { BitwardenToastModule } from 'jslib-angular/components/toastr.component';
 
 import { A11yTitleDirective } from 'jslib-angular/directives/a11y-title.directive';
 import { ApiActionDirective } from 'jslib-angular/directives/api-action.directive';
@@ -177,7 +176,10 @@ registerLocaleData(localeZhTw, 'zh-TW');
         FormsModule,
         ReactiveFormsModule,
         ServicesModule,
-        ToasterModule.forRoot(),
+        BitwardenToastModule.forRoot({
+            maxOpened: 5,
+            autoDismiss: true,
+        }),
         ScrollingModule,
         A11yModule,
     ],

--- a/src/app/vault/vault.component.ts
+++ b/src/app/vault/vault.component.ts
@@ -14,8 +14,6 @@ import {
 
 import { first } from 'rxjs/operators';
 
-import { ToasterService } from 'angular2-toaster';
-
 import { AddEditComponent } from './add-edit.component';
 import { AttachmentsComponent } from './attachments.component';
 import { CiphersComponent } from './ciphers.component';
@@ -86,7 +84,7 @@ export class VaultComponent implements OnInit, OnDestroy {
         private i18nService: I18nService, private modalService: ModalService,
         private broadcasterService: BroadcasterService, private changeDetectorRef: ChangeDetectorRef,
         private ngZone: NgZone, private syncService: SyncService,
-        private toasterService: ToasterService, private messagingService: MessagingService,
+        private messagingService: MessagingService,
         private platformUtilsService: PlatformUtilsService, private eventService: EventService,
         private totpService: TotpService, private userService: UserService,
         private passwordRepromptService: PasswordRepromptService) { }
@@ -651,7 +649,7 @@ export class VaultComponent implements OnInit, OnDestroy {
             }
 
             this.platformUtilsService.copyToClipboard(value);
-            this.toasterService.popAsync('info', null,
+            this.platformUtilsService.showToast('info', null,
                 this.i18nService.t('valueCopied', this.i18nService.t(labelI18nKey)));
             if (this.action === 'view') {
                 this.messagingService.send('minimizeOnCopy');

--- a/src/scss/plugins.scss
+++ b/src/scss/plugins.scss
@@ -1,43 +1,41 @@
 $fa-font-path: "~font-awesome/fonts";
 @import "~font-awesome/scss/font-awesome.scss";
-@import "~angular2-toaster/toaster";
+@import '~ngx-toastr/toastr';
 @import "~sweetalert2/src/sweetalert2.scss";
 
 @import "variables.scss";
 
 .toast-container {
     .toast-close-button {
-        margin-right: 4px;
         font-size: 18px;
+        margin-right: 4px;
     }
 
-    .toast {
-        opacity: 1 !important;
+    .ngx-toastr {
+        align-items: center;
         background-image: none !important;
         border-radius: $border-radius;
         box-shadow: 0 0 8px rgba(0, 0, 0, 0.35);
         display: flex;
-        align-items: center;
+        padding: 15px;
+
+        .toast-close-button {
+            position: absolute;
+            right: 5px;
+            top: 0;
+        }
 
         &:hover {
             box-shadow: 0 0 10px rgba(0, 0, 0, 0.6);
         }
 
-        &:before {
+        .icon i::before {
+            float: left;
+            font-style: normal;
             font-family: FontAwesome;
             font-size: 25px;
             line-height: 20px;
-            float: left;
-            color: #ffffff;
-            margin: auto 0 auto 15px;
-        }
-
-        .toast-content {
-            padding: 15px;
-        }
-
-        .toaster-icon {
-            display: none;
+            padding-right: 15px;
         }
 
         .toast-message {
@@ -51,49 +49,41 @@ $fa-font-path: "~font-awesome/fonts";
         }
 
         &.toast-danger, &.toast-error {
-            background-image: none !important;
-
             @include themify($themes) {
                 background-color: themed('dangerColor');
             }
 
-            &:before {
+            .icon i::before {
                 content: "\f0e7";
             }
         }
 
         &.toast-warning {
-            background-image: none !important;
-
             @include themify($themes) {
                 background-color: themed('warningColor');
             }
 
-            &:before {
+            .icon i::before {
                 content: "\f071";
             }
         }
 
         &.toast-info {
-            background-image: none !important;
-
             @include themify($themes) {
                 background-color: themed('infoColor');
             }
 
-            &:before {
+            .icon i:before {
                 content: "\f05a";
             }
         }
 
         &.toast-success {
-            background-image: none !important;
-
             @include themify($themes) {
                 background-color: themed('successColor');
             }
 
-            &:before {
+            .icon i:before {
                 content: "\f00C";
             }
         }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [x] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
As a part of upgrading Angular, I noticed that the toaster library we use still depends on Angular 11. This PR replaces our current toaster library with `ngx-toastr`.

While at it, I replaced all direct calls to the library with `platformUtilsService.showToast` which will make it easier to do these changes in the future. (Please do not call the toaster library directly in the future!)

Depends on: https://github.com/bitwarden/jslib/pull/568


## Code changes
<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

Removed toasterService from every component and used platformUtilsService instead. Note I didn't spend any time on formating the constructors since that will be a moot point soon.

## Testing requirements
<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

Regression sweep to ensure toasts still behave correctly.


## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
