### PR TITLE
[bug] Apply background color for light theme's account switcher

### DIFF
--- a/src/scss/variables.scss
+++ b/src/scss/variables.scss
@@ -90,7 +90,7 @@ $themes: (
     passwordSpecialColor: #c40800,
     calloutBorderColor: $border-color-dark,
     calloutBackgroundColor: $background-color,
-    acccountSwitcherBackgroundColor: $background-color,
+    accountSwitcherBackgroundColor: $background-color,
     accountSwitcherTextColor: #ffffff,
   ),
   dark: (


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When using light theme the account switcher does not have a background color applied and is transparent. This only effects light theme.
![image](https://user-images.githubusercontent.com/15897251/147599971-61121786-12ec-483a-83a0-9a214483fbaf.png)

## Code changes
* Correct a typo in the light theme scss variables

## Screenshots
<img width="352" alt="Screen Shot 2021-12-28 at 2 21 54 PM" src="https://user-images.githubusercontent.com/15897251/147599948-77bd8cd0-1fdf-4f22-94bd-6f759ef55170.png">

## Before you submit
- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
