### PR TITLE
Fix menu separators

### DIFF
--- a/src/main/menu.bitwarden.ts
+++ b/src/main/menu.bitwarden.ts
@@ -16,22 +16,33 @@ export class BitwardenMenu implements IMenubarMenu {
   readonly label: string = "Bitwarden";
 
   get items(): MenuItemConstructorOptions[] {
-    return [
-      this.aboutBitwarden,
-      this.checkForUpdates,
-      this.separator,
-      this.settings,
-      this.lock,
-      this.lockAll,
-      this.logOut,
-      this.services,
-      this.separator,
-      this.hideBitwarden,
-      this.hideOthers,
-      this.showAll,
-      this.separator,
-      this.quitBitwarden,
-    ];
+    let items = [this.aboutBitwarden, this.checkForUpdates];
+    if (this.aboutBitwarden.visible === true || this.checkForUpdates.visible === true) {
+      items.push(this.separator);
+    }
+    items.push(this.settings);
+    items.push(this.lock);
+    items.push(this.lockAll);
+    items.push(this.logOut);
+    items.push(this.services);
+
+    if (
+      this.hideBitwarden.visible === true ||
+      this.hideOthers.visible === true ||
+      this.showAll.visible === true
+    ) {
+      items.push(this.separator);
+    }
+
+    items.push(this.hideBitwarden);
+    items.push(this.hideOthers);
+    items.push(this.showAll);
+
+    if (this.quitBitwarden.visible === true) {
+      items.push(this.separator);
+    }
+    items.push(this.quitBitwarden);
+    return items;
   }
 
   private readonly _i18nService: I18nService;

--- a/src/main/menu.bitwarden.ts
+++ b/src/main/menu.bitwarden.ts
@@ -16,7 +16,7 @@ export class BitwardenMenu implements IMenubarMenu {
   readonly label: string = "Bitwarden";
 
   get items(): MenuItemConstructorOptions[] {
-    let items = [this.aboutBitwarden, this.checkForUpdates];
+    const items = [this.aboutBitwarden, this.checkForUpdates];
     if (this.aboutBitwarden.visible === true || this.checkForUpdates.visible === true) {
       items.push(this.separator);
     }

--- a/src/main/menu.window.ts
+++ b/src/main/menu.window.ts
@@ -16,6 +16,10 @@ export class WindowMenu implements IMenubarMenu {
   }
 
   get items(): MenuItemConstructorOptions[] {
+    if (!isMacAppStore()) {
+      return [this.hideToMenu, this.alwaysOnTop];
+    }
+
     return [
       this.minimize,
       this.hideToMenu,


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
As some menu item would be invisible in certain configurations (i.e. `isMacAppStore`) the separators would still be displayed even when not needed.

Asana task: https://app.asana.com/0/1200804338582616/1201624185800839/f

## Code changes

- **src/main/menu.bitwarden.ts:** Add check for invisible items and only add menu separators when necessary
- **src/main/menu.window.ts:** Add check for isMacAppStore and only then display separators

## Screenshots

**BEFORE**
![before_bitwardenMenu](https://user-images.githubusercontent.com/2670567/148381592-f6fb0dba-a3f6-4549-a3f7-dd50c369b1dd.PNG)
![before_windowMenu](https://user-images.githubusercontent.com/2670567/148381605-cbe3e9ac-7023-4a88-a3d7-7a7c37f78d09.PNG)

**AFTER**
![after_bitwardenMenu](https://user-images.githubusercontent.com/2670567/148381618-dc757000-a890-41ee-96f0-8dfa8a06cc8c.PNG)
![after_windowMenu](https://user-images.githubusercontent.com/2670567/148381628-2c8f9d6a-163f-4ab6-804a-2149516ca9b8.PNG)

## Testing requirements
Test that no unnecessary separators are displayed

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
