### PR TITLE
Fix null ref when building/updating the MenuBar

### DIFF
--- a/src/main/menubar.ts
+++ b/src/main/menubar.ts
@@ -52,6 +52,15 @@ export class Menubar {
     appVersion: string,
     updateRequest?: MenuUpdateRequest
   ) {
+    let isLocked = true;
+    if (
+      updateRequest != null &&
+      updateRequest.accounts != null &&
+      updateRequest.activeUserId != null
+    ) {
+      isLocked = updateRequest.accounts[updateRequest.activeUserId]?.isLocked ?? true;
+    }
+
     this.items = [
       new BitwardenMenu(
         i18nService,
@@ -60,28 +69,10 @@ export class Menubar {
         windowMain.win,
         updateRequest?.accounts
       ),
-      new FileMenu(
-        i18nService,
-        messagingService,
-        updateRequest?.accounts[updateRequest?.activeUserId]?.isLocked ?? true
-      ),
-      new EditMenu(
-        i18nService,
-        messagingService,
-        updateRequest?.accounts[updateRequest?.activeUserId]?.isLocked ?? true
-      ),
-      new ViewMenu(
-        i18nService,
-        messagingService,
-        updateRequest?.accounts[updateRequest?.activeUserId]?.isLocked ?? true
-      ),
-      new AccountMenu(
-        i18nService,
-        messagingService,
-        webVaultUrl,
-        windowMain.win,
-        updateRequest?.accounts[updateRequest?.activeUserId]?.isLocked ?? true
-      ),
+      new FileMenu(i18nService, messagingService, isLocked),
+      new EditMenu(i18nService, messagingService, isLocked),
+      new ViewMenu(i18nService, messagingService, isLocked),
+      new AccountMenu(i18nService, messagingService, webVaultUrl, windowMain.win, isLocked),
       new WindowMenu(i18nService, messagingService, windowMain),
       new AboutMenu(i18nService, appVersion, windowMain.win, updaterMain),
       new HelpMenu(i18nService, webVaultUrl),


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When creating the MenuBar and no account is present (new install) then a null ref would occur when building the menu. 

```
(node:35260) UnhandledPromiseRejectionWarning: TypeError: Cannot read properties of null (reading 'null')
[Main]     at new Menubar (C:\git\bitwarden\temp\desktop\build\main.js:56910:58)
[Main]     at MenuMain.<anonymous> (C:\git\bitwarden\temp\desktop\build\main.js:56631:75)
[Main]     at Generator.next (<anonymous>)
[Main]     at fulfilled (C:\git\bitwarden\temp\desktop\build\main.js:56603:58)
```
Asana task: https://app.asana.com/0/1200804338582616/1201650511310595/f
## Code changes

- **src\main\menubar.ts:** Check for undefined state on updateRequest

## Testing requirements
No error should occur on the console when opening up a fresh install

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
