### PR TITLE
Close opened AccountSwitcher dropdown when out of focus

### DIFF
--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -24,6 +24,9 @@
 <ng-template
   cdkConnectedOverlay
   [cdkConnectedOverlayOrigin]="trigger"
+  [cdkConnectedOverlayHasBackdrop]="true"
+  [cdkConnectedOverlayBackdropClass]="'cdk-overlay-transparent-backdrop'"
+  (backdropClick)="toggle()"
   [cdkConnectedOverlayOpen]="isOpen"
   cdkConnectedOverlayMinWidth="250px"
 >


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

When a user clicks outside of an opened account switching dropdown, it should close automatically when clicking outside of the dropdown.

Asana task: https://app.asana.com/0/1201648796371593/1201646438218288/f

## Code changes
- **src/app/layout/account-switcher.component.html:** Add cskConnectedOverlay options to close the dropdown when clicking outside of the dropdown

## Testing requirements
When the account switching dropdown is opened it should close by either selecting another account or clicking outside of it.

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
