### PR TITLE
Do not switch accounts if it is already the active account

### DIFF
--- a/src/app/layout/account-switcher.component.ts
+++ b/src/app/layout/account-switcher.component.ts
@@ -89,8 +89,12 @@ export class AccountSwitcherComponent implements OnInit {
   }
 
   async switch(userId: string) {
-    this.messagingService.send("switchAccount", { userId: userId });
     this.toggle();
+
+    if (userId === (await this.stateService.getUserId())) {
+      return;
+    }
+    this.messagingService.send("switchAccount", { userId: userId });
   }
 
   private async createSwitcherAccounts(baseAccounts: {


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When selecting an account from the account switcher, we would trigger the whole account switching even if the selected account equals the current account.

Asana task: https://app.asana.com/0/1201648796371593/1201642542946844/f
## Code changes

- **src/app/layout/account-switcher.component.ts:** When an account is selected always toggle the account switching dropdown but only send a message to switch accounts if the selected accounts does not match the current.

## Testing requirements
When selecting the current account, no loading or syncing should occur. Just closes the dropdown.
Selecting another account other than the current should obviously switch to the selected account.

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
