### PR TITLE
[Bug] VaultTimeout incorrectly defaults to "Never"

### DIFF
--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -10,8 +10,9 @@ import { I18nService } from "../services/i18n.service";
 import { LoginGuardService } from "../services/loginGuard.service";
 import { NativeMessagingService } from "../services/nativeMessaging.service";
 import { PasswordRepromptService } from "../services/passwordReprompt.service";
-import { SearchBarService } from "./layout/search/search-bar.service";
 import { StateService } from "../services/state.service";
+
+import { SearchBarService } from "./layout/search/search-bar.service";
 
 import { JslibServicesModule } from "jslib-angular/services/jslib-services.module";
 

--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -11,6 +11,7 @@ import { LoginGuardService } from "../services/loginGuard.service";
 import { NativeMessagingService } from "../services/nativeMessaging.service";
 import { PasswordRepromptService } from "../services/passwordReprompt.service";
 import { SearchBarService } from "./layout/search/search-bar.service";
+import { StateService } from "../services/state.service";
 
 import { JslibServicesModule } from "jslib-angular/services/jslib-services.module";
 
@@ -35,6 +36,7 @@ import { NotificationsService as NotificationsServiceAbstraction } from "jslib-c
 import { PasswordRepromptService as PasswordRepromptServiceAbstraction } from "jslib-common/abstractions/passwordReprompt.service";
 import { PlatformUtilsService as PlatformUtilsServiceAbstraction } from "jslib-common/abstractions/platformUtils.service";
 import { StateService as StateServiceAbstraction } from "jslib-common/abstractions/state.service";
+import { StateMigrationService as StateMigrationServiceAbstraction } from "jslib-common/abstractions/stateMigration.service";
 import { StorageService as StorageServiceAbstraction } from "jslib-common/abstractions/storage.service";
 import { SyncService as SyncServiceAbstraction } from "jslib-common/abstractions/sync.service";
 import { SystemService as SystemServiceAbstraction } from "jslib-common/abstractions/system.service";
@@ -167,6 +169,16 @@ export function initFactory(
       provide: LoginGuardService,
       useClass: LoginGuardService,
       deps: [StateServiceAbstraction, PlatformUtilsServiceAbstraction, I18nServiceAbstraction],
+    },
+    {
+      provide: StateServiceAbstraction,
+      useClass: StateService,
+      deps: [
+        StorageServiceAbstraction,
+        "SECURE_STORAGE",
+        LogServiceAbstraction,
+        StateMigrationServiceAbstraction,
+      ],
     },
   ],
 })

--- a/src/models/account.ts
+++ b/src/models/account.ts
@@ -1,0 +1,20 @@
+import {
+  Account as BaseAccount,
+  AccountSettings as BaseAccountSettings,
+} from "jslib-common/models/domain/account";
+
+export class AccountSettings extends BaseAccountSettings {
+  vaultTimeout: number = -1; // On Restart
+}
+
+export class Account extends BaseAccount {
+  settings?: AccountSettings = new AccountSettings();
+
+  constructor(init: Partial<Account>) {
+    super(init);
+    Object.assign(this.settings, {
+      ...new AccountSettings(),
+      ...this.settings,
+    });
+  }
+}

--- a/src/services/state.service.ts
+++ b/src/services/state.service.ts
@@ -1,0 +1,13 @@
+import { StateService as BaseStateService } from "jslib-common/services/state.service";
+
+import { Account } from "../models/account";
+
+import { StateService as StateServiceAbstraction } from "jslib-common/abstractions/state.service";
+
+export class StateService extends BaseStateService<Account> implements StateServiceAbstraction {
+  async addAccount(account: Account) {
+    // Apply desktop overides to default account values
+    account = new Account(account);
+    await super.addAccount(account);
+  }
+}


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The default desktop vault timeout value is "On Restart", but there is no default set for this in the state service and account model. This PR extends the StateService and Account model to consider the special vault timeout default requirements needed for desktop.

This PR also updates jslib to pull in related changes from https://github.com/bitwarden/jslib/pull/607

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
