### PR TITLE
Fix logging out of all accounts instead of one

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -434,6 +434,10 @@ export class AppComponent implements OnInit {
   }
 
   private async logOut(expired: boolean, userId?: string) {
+    if (!userId) {
+      userId = await this.stateService.getUserId();
+    }
+
     await Promise.all([
       this.eventService.uploadEvents(userId),
       this.syncService.setLastSync(new Date(0), userId),


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When a user clicks on "Lock all vaults" they are brought onto the lock screen of the last active account. Then clicking on Logout would log out all users instead of switching to the other locked account.

Also when logged in with two users and then logging out via the context menu it would log you out of all accounts.

Asana tasks: 

https://app.asana.com/0/1201648796371593/1201627172404375/f
https://app.asana.com/0/1201648796371593/1201642542946835/f

## Code changes
- **src/app/app.component.ts:** When logOut is triggered and the userId is not provided. Retrieve currentUserId

## Testing requirements
Have multiple accounts logged in.

- **1st case**
Log out via the context menu and it should switch to the other account.

- **2nd case**
Lock all vaults and you get brought back onto the lock screen, clicking logout there should also switch to the other accounts lock screen.

- **3rd case**
In no scenerio should the email address on the lock screen look like `__$1__`
## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
