### PR TITLE
[Account Switching] Fix menus

### DIFF
--- a/src/main/menu.about.ts
+++ b/src/main/menu.about.ts
@@ -10,12 +10,8 @@ import { IMenubarMenu } from "./menubar";
 export class AboutMenu implements IMenubarMenu {
   readonly id: string = "about";
 
-  get visible(): boolean {
-    return !isMac();
-  }
-
   get label(): string {
-    return this.localize("about");
+    return "";
   }
 
   get items(): MenuItemConstructorOptions[] {

--- a/src/main/menu.account.ts
+++ b/src/main/menu.account.ts
@@ -27,20 +27,20 @@ export class AccountMenu implements IMenubarMenu {
   private readonly _messagingService: MessagingService;
   private readonly _webVaultUrl: string;
   private readonly _window: BrowserWindow;
-  private readonly _isAuthenticated: boolean;
+  private readonly _isLocked: boolean;
 
   constructor(
     i18nService: I18nService,
     messagingService: MessagingService,
     webVaultUrl: string,
     window: BrowserWindow,
-    isAuthenticated: boolean
+    isLocked: boolean
   ) {
     this._i18nService = i18nService;
     this._messagingService = messagingService;
     this._webVaultUrl = webVaultUrl;
     this._window = window;
-    this._isAuthenticated = isAuthenticated;
+    this._isLocked = isLocked;
   }
 
   private get premiumMembership(): MenuItemConstructorOptions {
@@ -49,7 +49,7 @@ export class AccountMenu implements IMenubarMenu {
       click: () => this.sendMessage("openPremium"),
       id: "premiumMembership",
       visible: !isWindowsStore() && !isMacAppStore(),
-      enabled: this._isAuthenticated,
+      enabled: !this._isLocked,
     };
   }
 
@@ -71,7 +71,7 @@ export class AccountMenu implements IMenubarMenu {
           shell.openExternal(this._webVaultUrl);
         }
       },
-      enabled: this._isAuthenticated,
+      enabled: !this._isLocked,
     };
   }
 
@@ -93,7 +93,7 @@ export class AccountMenu implements IMenubarMenu {
           shell.openExternal(this._webVaultUrl);
         }
       },
-      enabled: this._isAuthenticated,
+      enabled: !this._isLocked,
     };
   }
 
@@ -102,7 +102,7 @@ export class AccountMenu implements IMenubarMenu {
       label: this.localize("fingerprintPhrase"),
       id: "fingerprintPhrase",
       click: () => this.sendMessage("showFingerprintPhrase"),
-      enabled: this._isAuthenticated,
+      enabled: !this._isLocked,
     };
   }
 

--- a/src/main/menu.edit.ts
+++ b/src/main/menu.edit.ts
@@ -31,16 +31,12 @@ export class EditMenu implements IMenubarMenu {
 
   private readonly _i18nService: I18nService;
   private readonly _messagingService: MessagingService;
-  private readonly _isAuthenticated: boolean;
+  private readonly _isLocked: boolean;
 
-  constructor(
-    i18nService: I18nService,
-    messagingService: MessagingService,
-    isAuthenticated: boolean
-  ) {
+  constructor(i18nService: I18nService, messagingService: MessagingService, isLocked: boolean) {
     this._i18nService = i18nService;
     this._messagingService = messagingService;
-    this._isAuthenticated = isAuthenticated;
+    this._isLocked = isLocked;
   }
 
   private get undo(): MenuItemConstructorOptions {
@@ -101,7 +97,7 @@ export class EditMenu implements IMenubarMenu {
       id: "copyUsername",
       click: () => this.sendMessage("copyUsername"),
       accelerator: "CmdOrCtrl+U",
-      enabled: this._isAuthenticated,
+      enabled: !this._isLocked,
     };
   }
 
@@ -111,7 +107,7 @@ export class EditMenu implements IMenubarMenu {
       id: "copyPassword",
       click: () => this.sendMessage("copyPassword"),
       accelerator: "CmdOrCtrl+P",
-      enabled: this._isAuthenticated,
+      enabled: !this._isLocked,
     };
   }
 
@@ -121,6 +117,7 @@ export class EditMenu implements IMenubarMenu {
       id: "copyTotp",
       click: () => this.sendMessage("copyTotp"),
       accelerator: "CmdOrCtrl+T",
+      enabled: !this._isLocked,
     };
   }
 

--- a/src/main/menu.file.ts
+++ b/src/main/menu.file.ts
@@ -28,16 +28,12 @@ export class FileMenu implements IMenubarMenu {
 
   private readonly _i18nService: I18nService;
   private readonly _messagingService: MessagingService;
-  private readonly _isAuthenticated: boolean;
+  private readonly _isLocked: boolean;
 
-  constructor(
-    i18nService: I18nService,
-    messagingService: MessagingService,
-    isAuthenticated: boolean
-  ) {
+  constructor(i18nService: I18nService, messagingService: MessagingService, isLocked: boolean) {
     this._i18nService = i18nService;
     this._messagingService = messagingService;
-    this._isAuthenticated = isAuthenticated;
+    this._isLocked = isLocked;
   }
 
   private get addNewLogin(): MenuItemConstructorOptions {
@@ -46,6 +42,7 @@ export class FileMenu implements IMenubarMenu {
       click: () => this.sendMessage("newLogin"),
       accelerator: "CmdOrCtrl+N",
       id: "addNewLogin",
+      enabled: !this._isLocked,
     };
   }
 
@@ -54,7 +51,7 @@ export class FileMenu implements IMenubarMenu {
       label: this.localize("addNewItem"),
       id: "addNewItem",
       submenu: this.addNewItemSubmenu,
-      enabled: this._isAuthenticated,
+      enabled: !this._isLocked,
     };
   }
 
@@ -92,6 +89,7 @@ export class FileMenu implements IMenubarMenu {
       id: "addNewFolder",
       label: this.localize("addNewFolder"),
       click: () => this.sendMessage("newFolder"),
+      enabled: !this._isLocked,
     };
   }
 
@@ -104,6 +102,7 @@ export class FileMenu implements IMenubarMenu {
       id: "syncVault",
       label: this.localize("syncVault"),
       click: () => this.sendMessage("syncVault"),
+      enabled: !this._isLocked,
     };
   }
 
@@ -112,6 +111,7 @@ export class FileMenu implements IMenubarMenu {
       id: "exportVault",
       label: this.localize("exportVault"),
       click: () => this.sendMessage("exportVault"),
+      enabled: !this._isLocked,
     };
   }
 

--- a/src/main/menu.help.ts
+++ b/src/main/menu.help.ts
@@ -6,6 +6,7 @@ import { shell } from "electron";
 import { isMacAppStore, isWindowsStore } from "jslib-electron/utils";
 
 import { MenuItemConstructorOptions } from "electron";
+import { AboutMenu } from "./menu.about";
 
 export class HelpMenu implements IMenubarMenu {
   readonly id: string = "help";
@@ -15,7 +16,7 @@ export class HelpMenu implements IMenubarMenu {
   }
 
   get items(): MenuItemConstructorOptions[] {
-    return [
+    const items = [
       this.emailUs,
       this.visitOurWebsite,
       this.fileBugReport,
@@ -28,14 +29,21 @@ export class HelpMenu implements IMenubarMenu {
       this.getMobileApp,
       this.getBrowserExtension,
     ];
+
+    if (this._aboutMenu != null) {
+      items.push(...this._aboutMenu.items);
+    }
+    return items;
   }
 
   private readonly _i18nService: I18nService;
   private readonly _webVaultUrl: string;
+  private readonly _aboutMenu: AboutMenu;
 
-  constructor(i18nService: I18nService, webVaultUrl: string) {
+  constructor(i18nService: I18nService, webVaultUrl: string, aboutMenu: AboutMenu) {
     this._i18nService = i18nService;
     this._webVaultUrl = webVaultUrl;
+    this._aboutMenu = aboutMenu;
   }
 
   private get emailUs(): MenuItemConstructorOptions {

--- a/src/main/menu.view.ts
+++ b/src/main/menu.view.ts
@@ -32,16 +32,12 @@ export class ViewMenu implements IMenubarMenu {
 
   private readonly _i18nService: I18nService;
   private readonly _messagingService: MessagingService;
-  private readonly _isAuthenticated: boolean;
+  private readonly _isLocked: boolean;
 
-  constructor(
-    i18nService: I18nService,
-    messagingService: MessagingService,
-    isAuthenticated: boolean
-  ) {
+  constructor(i18nService: I18nService, messagingService: MessagingService, isLocked: boolean) {
     this._i18nService = i18nService;
     this._messagingService = messagingService;
-    this._isAuthenticated = isAuthenticated;
+    this._isLocked = isLocked;
   }
 
   private get searchVault(): MenuItemConstructorOptions {
@@ -50,7 +46,7 @@ export class ViewMenu implements IMenubarMenu {
       label: this.localize("searchVault"),
       click: () => this.sendMessage("focusSearch"),
       accelerator: "CmdOrCtrl+F",
-      enabled: this._isAuthenticated,
+      enabled: !this._isLocked,
     };
   }
 
@@ -64,7 +60,7 @@ export class ViewMenu implements IMenubarMenu {
       label: this.localize("passwordGenerator"),
       click: () => this.sendMessage("openPasswordGenerator"),
       accelerator: "CmdOrCtrl+G",
-      enabled: this._isAuthenticated,
+      enabled: !this._isLocked,
     };
   }
 
@@ -73,7 +69,7 @@ export class ViewMenu implements IMenubarMenu {
       id: "passwordHistory",
       label: this.localize("passwordHistory"),
       click: () => this.sendMessage("openPasswordHistory"),
-      enabled: this._isAuthenticated,
+      enabled: !this._isLocked,
     };
   }
 

--- a/src/main/menubar.ts
+++ b/src/main/menubar.ts
@@ -74,8 +74,11 @@ export class Menubar {
       new ViewMenu(i18nService, messagingService, isLocked),
       new AccountMenu(i18nService, messagingService, webVaultUrl, windowMain.win, isLocked),
       new WindowMenu(i18nService, messagingService, windowMain),
-      new AboutMenu(i18nService, appVersion, windowMain.win, updaterMain),
-      new HelpMenu(i18nService, webVaultUrl),
+      new HelpMenu(
+        i18nService,
+        webVaultUrl,
+        new AboutMenu(i18nService, appVersion, windowMain.win, updaterMain)
+      ),
     ];
   }
 }


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Several menu items would be enabled when they shouldn't and vice-versa.

There was also an empty about menu. I removed the main entry and moved it's items back into the help menu where they resided beforehand.

Asana task: https://app.asana.com/0/1201648796371593/1201631142348199/f

## Code changes
- Fixed the enable/disable flag based on the vaults locked state
- **src/main/menu.account.ts:** 
- **src/main/menu.edit.ts:** 
- **src/main/menu.file.ts:** 
- **src/main/menu.view.ts:** 

- **src/main/menu.about.ts:** Remove title and visibility flag
- **src/main/menu.help.ts :** Added the AboutMenu to the constructor and passed the AboutMenu-items out with the HelpMenuItems
- **src/main/menubar.ts:** Pass in params for changed HelpMenu constructor

## Testing requirements
All menu items that should behave on a unlocked vault (current) should be enabled.
If the current vault is locked all those items should be disabled

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
