### PR TITLE
[Bug] [Account Switching] Improve State Management Performance

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -132,10 +132,10 @@ export class AppComponent implements OnInit {
       }, 1000);
 
       if (activeUserId != null) {
-          window.ontouchstart = () => this.recordActivity(activeUserId);
-          window.onmousedown = () => this.recordActivity(activeUserId);
-          window.onscroll = () => this.recordActivity(activeUserId);
-          window.onkeypress = () => this.recordActivity(activeUserId);
+        window.ontouchstart = () => this.recordActivity(activeUserId);
+        window.onmousedown = () => this.recordActivity(activeUserId);
+        window.onscroll = () => this.recordActivity(activeUserId);
+        window.onkeypress = () => this.recordActivity(activeUserId);
       }
     });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -131,10 +131,12 @@ export class AppComponent implements OnInit {
         await this.updateAppMenu();
       }, 1000);
 
-      window.ontouchstart = () => this.recordActivity(activeUserId);
-      window.onmousedown = () => this.recordActivity(activeUserId);
-      window.onscroll = () => this.recordActivity(activeUserId);
-      window.onkeypress = () => this.recordActivity(activeUserId);
+      if (activeUserId != null) {
+          window.ontouchstart = () => this.recordActivity(activeUserId);
+          window.onmousedown = () => this.recordActivity(activeUserId);
+          window.onscroll = () => this.recordActivity(activeUserId);
+          window.onkeypress = () => this.recordActivity(activeUserId);
+      }
     });
 
     this.broadcasterService.subscribe(BroadcasterSubscriptionId, async (message: any) => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -159,7 +159,9 @@ export class AppComponent implements OnInit {
             this.router.navigate(["login"]);
             break;
           case "logout":
+            this.loading = true;
             await this.logOut(!!message.expired, message.userId);
+            this.loading = false;
             break;
           case "lockVault":
             await this.vaultTimeoutService.lock(true, message.userId);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -122,15 +122,19 @@ export class AppComponent implements OnInit {
   ) {}
 
   ngOnInit() {
+    let activeUserId: string = null;
+    this.stateService.activeAccount.subscribe((userId) => {
+      activeUserId = userId;
+    });
     this.ngZone.runOutsideAngular(() => {
       setTimeout(async () => {
         await this.updateAppMenu();
       }, 1000);
 
-      window.ontouchstart = () => this.recordActivity();
-      window.onmousedown = () => this.recordActivity();
-      window.onscroll = () => this.recordActivity();
-      window.onkeypress = () => this.recordActivity();
+      window.ontouchstart = () => this.recordActivity(activeUserId);
+      window.onmousedown = () => this.recordActivity(activeUserId);
+      window.onscroll = () => this.recordActivity(activeUserId);
+      window.onkeypress = () => this.recordActivity(activeUserId);
     });
 
     this.broadcasterService.subscribe(BroadcasterSubscriptionId, async (message: any) => {
@@ -475,14 +479,14 @@ export class AppComponent implements OnInit {
     await this.updateAppMenu();
   }
 
-  private async recordActivity() {
+  private async recordActivity(userId: string) {
     const now = new Date().getTime();
     if (this.lastActivity != null && now - this.lastActivity < 250) {
       return;
     }
 
     this.lastActivity = now;
-    await this.stateService.setLastActive(now);
+    await this.stateService.setLastActive(now, { userId: userId });
 
     // Idle states
     if (this.isIdle) {

--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -45,6 +45,10 @@ import { VaultTimeoutService as VaultTimeoutServiceAbstraction } from "jslib-com
 
 import { ThemeType } from "jslib-common/enums/themeType";
 
+import { Account } from "../models/account";
+
+import { AccountFactory } from "jslib-common/models/domain/account";
+
 export function initFactory(
   window: Window,
   environmentService: EnvironmentServiceAbstraction,
@@ -173,7 +177,19 @@ export function initFactory(
     },
     {
       provide: StateServiceAbstraction,
-      useClass: StateService,
+      useFactory: (
+        storageService: StorageServiceAbstraction,
+        secureStorageService: StorageServiceAbstraction,
+        logService: LogServiceAbstraction,
+        stateMigrationService: StateMigrationServiceAbstraction
+      ) =>
+        new StateService(
+          storageService,
+          secureStorageService,
+          logService,
+          stateMigrationService,
+          new AccountFactory(Account)
+        ),
       deps: [
         StorageServiceAbstraction,
         "SECURE_STORAGE",

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,8 @@ import { NativeMessagingMain } from "./main/nativeMessaging.main";
 
 import { StateService } from "jslib-common/services/state.service";
 
+import { Account, AccountFactory } from "jslib-common/models/domain/account";
+
 export class Main {
   logService: ElectronLogService;
   i18nService: I18nService;
@@ -79,7 +81,13 @@ export class Main {
     // TODO: this state service will have access to on disk storage, but not in memory storage.
     // If we could get this to work using the stateService singleton that the rest of the app uses we could save
     // ourselves from some hacks, like having to manually update the app menu vs. the menu subscribing to events.
-    this.stateService = new StateService(this.storageService, null, this.logService, null);
+    this.stateService = new StateService(
+      this.storageService,
+      null,
+      this.logService,
+      null,
+      new AccountFactory(Account)
+    );
 
     this.windowMain = new WindowMain(
       this.stateService,


### PR DESCRIPTION
* Dependent on https://github.com/bitwarden/jslib/pull/611

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Large vaults see a clear degrade in performance using the state service, especially when multiple vaults are authed and unlocked at the same time.

## Code changes
The performance concerns themselves are resolved mostly by implementing the AccountFactory parameter requirement that has been added to jslib in https://github.com/bitwarden/jslib/pull/611, since most performance boosts are coming from jslib.

I noticed a couple of small related issues outlined and resolved in the commits.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
