### PR TITLE
[Account switching]  Design changes

### DIFF
--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -65,8 +65,13 @@
       </a>
     </div>
     <div class="border"></div>
-    <a class="add" routerLink="/login" (click)="toggle()">
-      <i class="fa fa-plus" aria-hidden="true"></i> {{ "addAccount" | i18n }}
-    </a>
+    <ng-container *ngIf="numberOfAccounts < 5">
+      <a class="add" routerLink="/login" (click)="toggle()">
+        <i class="fa fa-plus" aria-hidden="true"></i> {{ "addAccount" | i18n }}
+      </a>
+    </ng-container>
+    <ng-container *ngIf="numberOfAccounts == 5">
+      <a class="accountLimitReached">{{ "accountSwitcherLimitReached" | i18n }} </a>
+    </ng-container>
   </div>
 </ng-template>

--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -39,9 +39,27 @@
         href="#"
         (mousedown)="switch(a.key)"
       >
-        <span class="email">{{ a.value.profile.email }}</span>
-        <span class="server">{{ a.value.serverUrl }}</span>
-        <span class="status">{{ a.value.profile.authenticationStatus }}</span>
+        <app-avatar
+          [data]="a.value.profile.email"
+          size="25"
+          [circle]="true"
+          [fontSize]="14"
+          [dynamic]="true"
+          *ngIf="a.value.profile.email != null"
+        ></app-avatar>
+        <div class="accountInfo">
+          <span class="email">{{ a.value.profile.email }}</span>
+          <span class="server">{{ a.value.serverUrl }}</span>
+          <span class="status">{{ a.value.profile.authenticationStatus }}</span>
+        </div>
+        <i
+          class="fa fa-unlock fa-2x text-muted"
+          *ngIf="a.value.profile.authenticationStatus == 'unlocked'"
+        ></i>
+        <i
+          class="fa fa-lock fa-2x text-muted"
+          *ngIf="a.value.profile.authenticationStatus == 'locked'"
+        ></i>
       </a>
     </div>
     <div class="border"></div>

--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -49,7 +49,9 @@
         ></app-avatar>
         <div class="accountInfo">
           <span class="email">{{ a.value.profile.email }}</span>
-          <span class="server">{{ a.value.serverUrl }}</span>
+          <span class="server" *ngIf="a.value.serverUrl != 'bitwarden.com'">{{
+            a.value.serverUrl
+          }}</span>
           <span class="status">{{ a.value.profile.authenticationStatus }}</span>
         </div>
         <i

--- a/src/app/layout/account-switcher.component.ts
+++ b/src/app/layout/account-switcher.component.ts
@@ -56,7 +56,19 @@ export class AccountSwitcherComponent implements OnInit {
   serverUrl: string;
 
   get showSwitcher() {
-    return this.accounts != null && Object.keys(this.accounts).length > 0;
+    if (this.activeAccountEmail != null) {
+      return true;
+    }
+
+    return this.numberOfAccounts > 0;
+  }
+
+  get numberOfAccounts() {
+    if (this.accounts == null) {
+      this.isOpen = false;
+      return 0;
+    }
+    return Object.keys(this.accounts).length;
   }
 
   constructor(

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1792,5 +1792,8 @@
   },
   "accountLimitReached": {
     "message": "No more than 5 accounts may be logged in at the same time."
+  },
+  "accountSwitcherLimitReached": {
+    "message": "Account limit reached. Log out of an account to add another."
   }
 }

--- a/src/scss/header.scss
+++ b/src/scss/header.scss
@@ -130,28 +130,33 @@
   }
 
   .accounts {
-    padding: 4px 0;
+    padding: 7px 0;
 
     .account {
       display: grid;
-      grid-column-gap: 5px;
-      grid-template:
-        [row1-start] "email  status" [row1-end]
-        [row2-start] "server server" [row2-end]
-        / 1fr auto;
-      align-items: baseline;
+      grid-template-columns: 24px auto 24px;
+      grid-column-gap: 11px;
+      align-items: center;
+      justify-items: left;
 
-      .server {
-        font-size: $font-size-small;
-      }
+      .accountInfo {
+        display: grid;
 
-      .email {
-        font-size: $font-size-large;
-      }
+        .email {
+          font-size: $font-size-base;
+          max-width: 168px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+        }
 
-      .status {
-        font-style: italic;
-        grid-area: status;
+        .server {
+          font-size: $font-size-small;
+        }
+
+        .status {
+          font-size: $font-size-small;
+          font-style: italic;
+        }
       }
     }
   }

--- a/src/scss/header.scss
+++ b/src/scss/header.scss
@@ -174,4 +174,9 @@
   .add {
     margin: 4px 0;
   }
+
+  .accountLimitReached {
+    margin: 4px 0;
+    font-size: $font-size-small;
+  }
 }


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
- Remove server url from accounts using BW's cloud server
https://app.asana.com/0/1201648796371593/1201665881786814/f

- Relocate account status to below email in the account switcher https://app.asana.com/0/1201648796371593/1201665881786815/f

- Add lock/unlock icons to the right side of account switcher items https://app.asana.com/0/1201648796371593/1201665881786816/f

- Long emails stretch account switcher dropdown and aren't abbreviated / Update max width of account switcher emails
https://app.asana.com/0/1201648796371593/1201631142348195/f and https://app.asana.com/0/1201648796371593/1201665881786817/f

- Add avatar to accounts in the switcher
https://app.asana.com/0/1201648796371593/1201665881786818/f

- Adjust padding of the account switcher content
https://app.asana.com/0/1201648796371593/1201665881786819/f

- Replace "add account" button with helper text when max number of authenticated accounts is reached
https://app.asana.com/0/1201648796371593/1201665881786820/f

## Code changes

- **src/app/layout/account-switcher.component.html:** 
  - Added avatar component
  - Wrap accountInfo (email, server, status) and display underneath eachother
  - Hide server url if accounts belongs to a cloud account
  - Display unlocked/lock icon depending on account state
  - Display account limit reached info (max 5 accounts)
- **src/app/layout/account-switcher.component.ts:** Added numberOfAccounts getter to decide when to show the account limit reached message.
- **src/locales/en/messages.json:** Added message for when the AccountSwitcher limit is reached 
- **src/scss/header.scss:** Various fixes to align with the Figma spec

## Screenshots
- **BEFORE:**
![account_switcher_before](https://user-images.githubusercontent.com/2670567/149772373-db2f9a2d-ec92-4c8f-968c-46c0618769ff.PNG)

- **AFTER:**
![account_switcher_after](https://user-images.githubusercontent.com/2670567/149772418-1b5ced62-ce2b-4f67-92d2-f792b1393968.PNG)

## Testing requirements
- The design changes should adhere to the Figma spec which can be found here: https://app.asana.com/0/1201648796371593/1201639978291810/f

- Long email should be capped at roughly 22 characters and an elipsis (...) should be shown

- The vault state icons should display the correct state (locked/unlocked) and should change as soon as the vault state changes.

- If a cloud account is registered the server url should not be displayed (only account email and vault state (active/locked/unlocked)

- Once 5 accounts have been registered the notice that the account limit has been reached should be shown instead of the add account menu item.

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
