### PR TITLE
[Account switching] Hide active account

### DIFF
--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -27,7 +27,7 @@
   [cdkConnectedOverlayHasBackdrop]="true"
   [cdkConnectedOverlayBackdropClass]="'cdk-overlay-transparent-backdrop'"
   (backdropClick)="toggle()"
-  [cdkConnectedOverlayOpen]="isOpen"
+  [cdkConnectedOverlayOpen]="showSwitcher && isOpen"
   cdkConnectedOverlayMinWidth="250px"
 >
   <div class="account-switcher-dropdown" [@transformPanel]="'open'">

--- a/src/app/layout/account-switcher.component.ts
+++ b/src/app/layout/account-switcher.component.ts
@@ -57,11 +57,7 @@ export class AccountSwitcherComponent implements OnInit {
   serverUrl: string;
 
   get showSwitcher() {
-    if (!Utils.isNullOrWhitespace(this.activeAccountEmail)) {
-      return true;
-    }
-
-    return false;
+    return !Utils.isNullOrWhitespace(this.activeAccountEmail);
   }
 
   constructor(
@@ -104,11 +100,7 @@ export class AccountSwitcherComponent implements OnInit {
   }): Promise<{ [userId: string]: SwitcherAccount }> {
     const switcherAccounts: { [userId: string]: SwitcherAccount } = {};
     for (const userId in baseAccounts) {
-      if (userId == null) {
-        continue;
-      }
-
-      if (userId === (await this.stateService.getUserId())) {
+      if (userId == null || userId === (await this.stateService.getUserId())) {
         continue;
       }
 

--- a/src/app/layout/account-switcher.component.ts
+++ b/src/app/layout/account-switcher.component.ts
@@ -96,9 +96,6 @@ export class AccountSwitcherComponent implements OnInit {
   async switch(userId: string) {
     this.toggle();
 
-    if (userId === (await this.stateService.getUserId())) {
-      return;
-    }
     this.messagingService.send("switchAccount", { userId: userId });
   }
 

--- a/src/app/layout/account-switcher.component.ts
+++ b/src/app/layout/account-switcher.component.ts
@@ -7,6 +7,7 @@ import { StateService } from "jslib-common/abstractions/state.service";
 import { VaultTimeoutService } from "jslib-common/abstractions/vaultTimeout.service";
 
 import { AuthenticationStatus } from "jslib-common/enums/authenticationStatus";
+import { Utils } from "jslib-common/misc/utils";
 
 import { Account } from "jslib-common/models/domain/account";
 
@@ -56,7 +57,11 @@ export class AccountSwitcherComponent implements OnInit {
   serverUrl: string;
 
   get showSwitcher() {
-    return this.accounts != null && Object.keys(this.accounts).length > 0;
+    if (!Utils.isNullOrWhitespace(this.activeAccountEmail)) {
+      return true;
+    }
+
+    return false;
   }
 
   constructor(
@@ -105,6 +110,11 @@ export class AccountSwitcherComponent implements OnInit {
       if (userId == null) {
         continue;
       }
+
+      if (userId === (await this.stateService.getUserId())) {
+        continue;
+      }
+
       // environmentUrls are stored on disk and must be retrieved seperatly from the in memory state offered from subscribing to accounts
       baseAccounts[userId].settings.environmentUrls = await this.stateService.getEnvironmentUrls({
         userId: userId,


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The current active account should only be visible on the switcher and not show up as an item in the dropdown

Asana task: https://app.asana.com/0/1201648796371593/1201665881786813/f

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **src/app/layout/account-switcher.component.html:** Tie the visibility of the dropdown to the visibility of the account switcher above it.
- **src/app/layout/account-switcher.component.ts:** 
  - Only show the switcher when an active account has been set (at least one account logged in)
  - Remove the current active account from the dropdown
  - No longer need to check if selected account is active before switching

## Screenshots
- **BEFORE:**
![image](https://user-images.githubusercontent.com/2670567/149785884-bf771cee-3257-47fb-a19a-0db276ee41fe.png)

- **AFTER:**
![image](https://user-images.githubusercontent.com/2670567/149785502-c9eb7892-4e96-4a06-ba62-7ce74a500686.png)

## Testing requirements
The currently active account should only appear on the account switcher but never in the dropdown. As soon as I have switched to another account, the account that was active before should be shown in the dropdown.

The switcher usually disappeared when no active account was present. The dropdown should now also close iof it was open before

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
