### PR TITLE
Bump electron from 16.0.2 to 16.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -129,7 +129,7 @@
       "dependencies": {
         "@bitwarden/jslib-common": "file:../common",
         "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
-        "electron": "16.0.2",
+        "electron": "16.0.7",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
         "electron-updater": "4.6.1",
@@ -3599,9 +3599,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.2.tgz",
-      "integrity": "sha512-kT746yVMztrP4BbT3nrFNcUcfgFu2yelUw6TWBVTy0pju+fBISaqcvoiMrq+8U0vRpoXSu2MJYygOf4T0Det7g==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.7.tgz",
+      "integrity": "sha512-/IMwpBf2svhA1X/7Q58RV+Nn0fvUJsHniG4TizaO7q4iKFYSQ6hBvsLz+cylcZ8hRMKmVy5G1XaMNJID2ah23w==",
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.13.0",
@@ -10501,7 +10501,7 @@
         "@bitwarden/jslib-common": "file:../common",
         "@nodert-win10-rs4/windows.security.credentials.ui": "^0.4.4",
         "@types/node": "^16.11.12",
-        "electron": "16.0.2",
+        "electron": "16.0.7",
         "electron-log": "4.4.1",
         "electron-store": "8.0.1",
         "electron-updater": "4.6.1",
@@ -12794,9 +12794,9 @@
       }
     },
     "electron": {
-      "version": "16.0.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.2.tgz",
-      "integrity": "sha512-kT746yVMztrP4BbT3nrFNcUcfgFu2yelUw6TWBVTy0pju+fBISaqcvoiMrq+8U0vRpoXSu2MJYygOf4T0Det7g==",
+      "version": "16.0.7",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-16.0.7.tgz",
+      "integrity": "sha512-/IMwpBf2svhA1X/7Q58RV+Nn0fvUJsHniG4TizaO7q4iKFYSQ6hBvsLz+cylcZ8hRMKmVy5G1XaMNJID2ah23w==",
       "requires": {
         "@electron/get": "^1.13.0",
         "@types/node": "^14.6.2",


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [X] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Pull in jslib to bump electron from 16.0.2 to 16.0.7
Asana task: https://app.asana.com/0/1200804338582616/1201660850797010/f
## Code changes

- **jslib:** Pull in changes from https://github.com/bitwarden/jslib/pull/613
- **package-lock.json:** Changes after executing `npm i`

## Testing requirements
Regression testing of desktop client

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
