### PR TITLE
[Account Switching] Design changes to settings menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3955,9 +3955,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "14.18.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-      "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
+      "version": "14.18.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.9.tgz",
+      "integrity": "sha512-j11XSuRuAlft6vLDEX4RvhqC0KxNxx6QIyMXNb0vHHSNPXTPeiy3algESWmOOIzEtiEL0qiowPU3ewW9hHVa7Q=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -12804,9 +12804,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.0.tgz",
-          "integrity": "sha512-0GeIl2kmVMXEnx8tg1SlG6Gg8vkqirrW752KqolYo1PHevhhZN3bhJ67qHj+bQaINhX0Ra3TlWwRvMCd9iEfNQ=="
+          "version": "14.18.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.9.tgz",
+          "integrity": "sha512-j11XSuRuAlft6vLDEX4RvhqC0KxNxx6QIyMXNb0vHHSNPXTPeiy3algESWmOOIzEtiEL0qiowPU3ewW9hHVa7Q=="
         }
       }
     },

--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -2,26 +2,31 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-body form">
-        <ng-container *ngIf="currentUserId != null">
+        <ng-container *ngIf="currentUserEmail != null">
           <div class="box">
-            <h2>
-              <button
-                type="button"
-                class="box-header-expandable"
-                (click)="showSecurity = !showSecurity"
-                [attr.aria-expanded]="showSecurity"
-              >
-                {{ "security" | i18n }}
-                <i
-                  *ngIf="!showSecurity"
-                  class="fa fa-chevron-down fa-sm icon"
-                  aria-hidden="true"
-                ></i>
-                <i *ngIf="showSecurity" class="fa fa-chevron-up fa-sm icon" aria-hidden="true"></i>
-              </button>
-            </h2>
-            <ng-container *ngIf="showSecurity">
-              <div class="box-content box-content-padded">
+            <label class="settingsTitle">{{ "settingsTitle" | i18n: currentUserEmail }} </label>
+            <div class="box-content box-content-padded">
+              <h2>
+                <button
+                  type="button"
+                  class="box-header-expandable"
+                  (click)="showSecurity = !showSecurity"
+                  [attr.aria-expanded]="showSecurity"
+                >
+                  {{ "security" | i18n }}
+                  <i
+                    *ngIf="!showSecurity"
+                    class="fa fa-chevron-down fa-sm icon"
+                    aria-hidden="true"
+                  ></i>
+                  <i
+                    *ngIf="showSecurity"
+                    class="fa fa-chevron-up fa-sm icon"
+                    aria-hidden="true"
+                  ></i>
+                </button>
+              </h2>
+              <ng-container *ngIf="showSecurity">
                 <app-vault-timeout-input
                   [vaultTimeouts]="vaultTimeouts"
                   [formControl]="vaultTimeout"
@@ -101,32 +106,32 @@
                     </label>
                   </div>
                 </div>
-              </div>
-            </ng-container>
+              </ng-container>
+            </div>
           </div>
           <div class="box">
-            <h2>
-              <button
-                type="button"
-                class="box-header-expandable"
-                (click)="showAccountPreferences = !showAccountPreferences"
-                [attr.aria-expanded]="showAccountPreferences"
-              >
-                {{ "accountPreferences" | i18n }}
-                <i
-                  *ngIf="!showAccountPreferences"
-                  class="fa fa-chevron-down fa-sm icon"
-                  aria-hidden="true"
-                ></i>
-                <i
-                  *ngIf="showAccountPreferences"
-                  class="fa fa-chevron-up fa-sm icon"
-                  aria-hidden="true"
-                ></i>
-              </button>
-            </h2>
-            <ng-container *ngIf="showAccountPreferences">
-              <div class="box-content box-content-padded">
+            <div class="box-content box-content-padded">
+              <h2>
+                <button
+                  type="button"
+                  class="box-header-expandable"
+                  (click)="showAccountPreferences = !showAccountPreferences"
+                  [attr.aria-expanded]="showAccountPreferences"
+                >
+                  {{ "accountPreferences" | i18n }}
+                  <i
+                    *ngIf="!showAccountPreferences"
+                    class="fa fa-chevron-down fa-sm icon"
+                    aria-hidden="true"
+                  ></i>
+                  <i
+                    *ngIf="showAccountPreferences"
+                    class="fa fa-chevron-up fa-sm icon"
+                    aria-hidden="true"
+                  ></i>
+                </button>
+              </h2>
+              <ng-container *ngIf="showAccountPreferences">
                 <div class="form-group">
                   <label for="clearClipboard">{{ "clearClipboard" | i18n }}</label>
                   <select
@@ -204,33 +209,33 @@
                     "enableBrowserIntegrationFingerprintDesc" | i18n
                   }}</small>
                 </div>
-              </div>
-            </ng-container>
+              </ng-container>
+            </div>
           </div>
         </ng-container>
         <div class="box">
-          <h2>
-            <button
-              type="button"
-              class="box-header-expandable"
-              (click)="showAppPreferences = !showAppPreferences"
-              [attr.aria-expanded]="showAppPreferences"
-            >
-              {{ "appPreferences" | i18n }}
-              <i
-                *ngIf="!showAppPreferences"
-                class="fa fa-chevron-down fa-sm icon"
-                aria-hidden="true"
-              ></i>
-              <i
-                *ngIf="showAppPreferences"
-                class="fa fa-chevron-up fa-sm icon"
-                aria-hidden="true"
-              ></i>
-            </button>
-          </h2>
-          <ng-container *ngIf="showAppPreferences">
-            <div class="box-content box-content-padded">
+          <div class="box-content box-content-padded">
+            <h2>
+              <button
+                type="button"
+                class="box-header-expandable"
+                (click)="showAppPreferences = !showAppPreferences"
+                [attr.aria-expanded]="showAppPreferences"
+              >
+                {{ "appPreferences" | i18n }}
+                <i
+                  *ngIf="!showAppPreferences"
+                  class="fa fa-chevron-down fa-sm icon"
+                  aria-hidden="true"
+                ></i>
+                <i
+                  *ngIf="showAppPreferences"
+                  class="fa fa-chevron-up fa-sm icon"
+                  aria-hidden="true"
+                ></i>
+              </button>
+            </h2>
+            <ng-container *ngIf="showAppPreferences">
               <div class="form-group">
                 <div class="checkbox">
                   <label for="enableTray">
@@ -335,8 +340,8 @@
                 </select>
                 <small class="help-block">{{ "languageDesc" | i18n }}</small>
               </div>
-            </div>
-          </ng-container>
+            </ng-container>
+          </div>
         </div>
       </div>
       <div class="modal-footer">

--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -2,206 +2,212 @@
   <div class="modal-dialog" role="document">
     <div class="modal-content">
       <div class="modal-body form">
-        <div class="box">
-          <h2>
-            <button
-              type="button"
-              class="box-header-expandable"
-              (click)="showSecurity = !showSecurity"
-              [attr.aria-expanded]="showSecurity"
-            >
-              {{ "security" | i18n }}
-              <i *ngIf="!showSecurity" class="fa fa-chevron-down fa-sm icon" aria-hidden="true"></i>
-              <i *ngIf="showSecurity" class="fa fa-chevron-up fa-sm icon" aria-hidden="true"></i>
-            </button>
-          </h2>
-          <ng-container *ngIf="showSecurity">
-            <div class="box-content box-content-padded">
-              <app-vault-timeout-input
-                [vaultTimeouts]="vaultTimeouts"
-                [formControl]="vaultTimeout"
-                ngDefaultControl
-              ></app-vault-timeout-input>
-              <div class="form-group">
-                <label>{{ "vaultTimeoutAction" | i18n }}</label>
-                <div class="radio radio-mt-2">
-                  <label for="vaultTimeoutActionLock">
-                    <input
-                      type="radio"
-                      name="VaultTimeoutAction"
-                      id="vaultTimeoutActionLock"
-                      value="lock"
-                      [(ngModel)]="vaultTimeoutAction"
-                      (change)="saveVaultTimeoutOptions()"
-                    />
-                    {{ "lock" | i18n }}
-                  </label>
+        <ng-container *ngIf="currentUserId != null">
+          <div class="box">
+            <h2>
+              <button
+                type="button"
+                class="box-header-expandable"
+                (click)="showSecurity = !showSecurity"
+                [attr.aria-expanded]="showSecurity"
+              >
+                {{ "security" | i18n }}
+                <i
+                  *ngIf="!showSecurity"
+                  class="fa fa-chevron-down fa-sm icon"
+                  aria-hidden="true"
+                ></i>
+                <i *ngIf="showSecurity" class="fa fa-chevron-up fa-sm icon" aria-hidden="true"></i>
+              </button>
+            </h2>
+            <ng-container *ngIf="showSecurity">
+              <div class="box-content box-content-padded">
+                <app-vault-timeout-input
+                  [vaultTimeouts]="vaultTimeouts"
+                  [formControl]="vaultTimeout"
+                  ngDefaultControl
+                ></app-vault-timeout-input>
+                <div class="form-group">
+                  <label>{{ "vaultTimeoutAction" | i18n }}</label>
+                  <div class="radio radio-mt-2">
+                    <label for="vaultTimeoutActionLock">
+                      <input
+                        type="radio"
+                        name="VaultTimeoutAction"
+                        id="vaultTimeoutActionLock"
+                        value="lock"
+                        [(ngModel)]="vaultTimeoutAction"
+                        (change)="saveVaultTimeoutOptions()"
+                      />
+                      {{ "lock" | i18n }}
+                    </label>
+                  </div>
+                  <small class="help-block">{{ "vaultTimeoutActionLockDesc" | i18n }}</small>
+                  <div class="radio">
+                    <label for="vaultTimeoutActionLogOut">
+                      <input
+                        type="radio"
+                        name="VaultTimeoutAction"
+                        id="vaultTimeoutActionLogOut"
+                        value="logOut"
+                        [(ngModel)]="vaultTimeoutAction"
+                        (change)="saveVaultTimeoutOptions()"
+                      />
+                      {{ "logOut" | i18n }}
+                    </label>
+                  </div>
+                  <small class="help-block">{{ "vaultTimeoutActionLogOutDesc" | i18n }}</small>
                 </div>
-                <small class="help-block">{{ "vaultTimeoutActionLockDesc" | i18n }}</small>
-                <div class="radio">
-                  <label for="vaultTimeoutActionLogOut">
-                    <input
-                      type="radio"
-                      name="VaultTimeoutAction"
-                      id="vaultTimeoutActionLogOut"
-                      value="logOut"
-                      [(ngModel)]="vaultTimeoutAction"
-                      (change)="saveVaultTimeoutOptions()"
-                    />
-                    {{ "logOut" | i18n }}
-                  </label>
+                <div class="form-group">
+                  <div class="checkbox">
+                    <label for="pin">
+                      <input
+                        id="pin"
+                        type="checkbox"
+                        name="PIN"
+                        [(ngModel)]="pin"
+                        (change)="updatePin()"
+                      />
+                      {{ "unlockWithPin" | i18n }}
+                    </label>
+                  </div>
                 </div>
-                <small class="help-block">{{ "vaultTimeoutActionLogOutDesc" | i18n }}</small>
-              </div>
-              <div class="form-group">
-                <div class="checkbox">
-                  <label for="pin">
-                    <input
-                      id="pin"
-                      type="checkbox"
-                      name="PIN"
-                      [(ngModel)]="pin"
-                      (change)="updatePin()"
-                    />
-                    {{ "unlockWithPin" | i18n }}
-                  </label>
+                <div class="form-group" *ngIf="supportsBiometric">
+                  <div class="checkbox">
+                    <label for="biometric">
+                      <input
+                        id="biometric"
+                        type="checkbox"
+                        name="biometric"
+                        [checked]="biometric"
+                        (change)="updateBiometric()"
+                      />
+                      {{ biometricText | i18n }}
+                    </label>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group" *ngIf="supportsBiometric">
-                <div class="checkbox">
-                  <label for="biometric">
-                    <input
-                      id="biometric"
-                      type="checkbox"
-                      name="biometric"
-                      [checked]="biometric"
-                      (change)="updateBiometric()"
-                    />
-                    {{ biometricText | i18n }}
-                  </label>
-                </div>
-              </div>
-              <div class="form-group" *ngIf="supportsBiometric">
-                <div class="checkbox">
-                  <label for="noAutoPromptBiometrics">
-                    <input
-                      id="noAutoPromptBiometrics"
-                      type="checkbox"
-                      name="noAutoPromptBiometrics"
-                      [(ngModel)]="noAutoPromptBiometrics"
-                      [disabled]="!biometric"
-                      (change)="updateNoAutoPromptBiometrics()"
-                    />
-                    {{ noAutoPromptBiometricsText | i18n }}
-                  </label>
+                <div class="form-group" *ngIf="supportsBiometric">
+                  <div class="checkbox">
+                    <label for="noAutoPromptBiometrics">
+                      <input
+                        id="noAutoPromptBiometrics"
+                        type="checkbox"
+                        name="noAutoPromptBiometrics"
+                        [(ngModel)]="noAutoPromptBiometrics"
+                        [disabled]="!biometric"
+                        (change)="updateNoAutoPromptBiometrics()"
+                      />
+                      {{ noAutoPromptBiometricsText | i18n }}
+                    </label>
+                  </div>
                 </div>
               </div>
-            </div>
-          </ng-container>
-        </div>
-        <div class="box">
-          <h2>
-            <button
-              type="button"
-              class="box-header-expandable"
-              (click)="showAccountPreferences = !showAccountPreferences"
-              [attr.aria-expanded]="showAccountPreferences"
-            >
-              {{ "accountPreferences" | i18n }}
-              <i
-                *ngIf="!showAccountPreferences"
-                class="fa fa-chevron-down fa-sm icon"
-                aria-hidden="true"
-              ></i>
-              <i
-                *ngIf="showAccountPreferences"
-                class="fa fa-chevron-up fa-sm icon"
-                aria-hidden="true"
-              ></i>
-            </button>
-          </h2>
-          <ng-container *ngIf="showAccountPreferences">
-            <div class="box-content box-content-padded">
-              <div class="form-group">
-                <label for="clearClipboard">{{ "clearClipboard" | i18n }}</label>
-                <select
-                  id="clearClipboard"
-                  name="ClearClipboard"
-                  [(ngModel)]="clearClipboard"
-                  (change)="saveClearClipboard()"
-                >
-                  <option *ngFor="let o of clearClipboardOptions" [ngValue]="o.value">
-                    {{ o.name }}
-                  </option>
-                </select>
-                <small class="help-block">{{ "clearClipboardDesc" | i18n }}</small>
-              </div>
-              <div class="form-group">
-                <div class="checkbox">
-                  <label for="minimizeOnCopyToClipboard">
-                    <input
-                      id="minimizeOnCopyToClipboard"
-                      type="checkbox"
-                      name="MinimizeOnCopyToClipboard"
-                      [(ngModel)]="minimizeOnCopyToClipboard"
-                      (change)="saveMinOnCopyToClipboard()"
-                    />
-                    {{ "minimizeOnCopyToClipboard" | i18n }}
-                  </label>
+            </ng-container>
+          </div>
+          <div class="box">
+            <h2>
+              <button
+                type="button"
+                class="box-header-expandable"
+                (click)="showAccountPreferences = !showAccountPreferences"
+                [attr.aria-expanded]="showAccountPreferences"
+              >
+                {{ "accountPreferences" | i18n }}
+                <i
+                  *ngIf="!showAccountPreferences"
+                  class="fa fa-chevron-down fa-sm icon"
+                  aria-hidden="true"
+                ></i>
+                <i
+                  *ngIf="showAccountPreferences"
+                  class="fa fa-chevron-up fa-sm icon"
+                  aria-hidden="true"
+                ></i>
+              </button>
+            </h2>
+            <ng-container *ngIf="showAccountPreferences">
+              <div class="box-content box-content-padded">
+                <div class="form-group">
+                  <label for="clearClipboard">{{ "clearClipboard" | i18n }}</label>
+                  <select
+                    id="clearClipboard"
+                    name="ClearClipboard"
+                    [(ngModel)]="clearClipboard"
+                    (change)="saveClearClipboard()"
+                  >
+                    <option *ngFor="let o of clearClipboardOptions" [ngValue]="o.value">
+                      {{ o.name }}
+                    </option>
+                  </select>
+                  <small class="help-block">{{ "clearClipboardDesc" | i18n }}</small>
                 </div>
-                <small class="help-block">{{ "minimizeOnCopyToClipboardDesc" | i18n }}</small>
-              </div>
-              <div class="form-group">
-                <div class="checkbox">
-                  <label for="disableFavicons">
-                    <input
-                      id="disableFavicons"
-                      type="checkbox"
-                      name="DisableFavicons"
-                      [(ngModel)]="disableFavicons"
-                      (change)="saveFavicons()"
-                    />
-                    {{ "disableFavicon" | i18n }}
-                  </label>
+                <div class="form-group">
+                  <div class="checkbox">
+                    <label for="minimizeOnCopyToClipboard">
+                      <input
+                        id="minimizeOnCopyToClipboard"
+                        type="checkbox"
+                        name="MinimizeOnCopyToClipboard"
+                        [(ngModel)]="minimizeOnCopyToClipboard"
+                        (change)="saveMinOnCopyToClipboard()"
+                      />
+                      {{ "minimizeOnCopyToClipboard" | i18n }}
+                    </label>
+                  </div>
+                  <small class="help-block">{{ "minimizeOnCopyToClipboardDesc" | i18n }}</small>
                 </div>
-                <small class="help-block">{{ "disableFaviconDesc" | i18n }}</small>
-              </div>
-              <div class="form-group">
-                <div class="checkbox">
-                  <label for="enableBrowserIntegration">
-                    <input
-                      id="enableBrowserIntegration"
-                      type="checkbox"
-                      name="EnableBrowserIntegration"
-                      [(ngModel)]="enableBrowserIntegration"
-                      (change)="saveBrowserIntegration()"
-                    />
-                    {{ "enableBrowserIntegration" | i18n }}
-                  </label>
+                <div class="form-group">
+                  <div class="checkbox">
+                    <label for="disableFavicons">
+                      <input
+                        id="disableFavicons"
+                        type="checkbox"
+                        name="DisableFavicons"
+                        [(ngModel)]="disableFavicons"
+                        (change)="saveFavicons()"
+                      />
+                      {{ "disableFavicon" | i18n }}
+                    </label>
+                  </div>
+                  <small class="help-block">{{ "disableFaviconDesc" | i18n }}</small>
                 </div>
-                <small class="help-block">{{ "enableBrowserIntegrationDesc" | i18n }}</small>
-              </div>
-              <div class="form-group">
-                <div class="checkbox">
-                  <label for="enableBrowserIntegrationFingerprint">
-                    <input
-                      id="enableBrowserIntegrationFingerprint"
-                      type="checkbox"
-                      name="EnableBrowserIntegrationFingerprint"
-                      [(ngModel)]="enableBrowserIntegrationFingerprint"
-                      (change)="saveBrowserIntegrationFingerprint()"
-                      [disabled]="!enableBrowserIntegration"
-                    />
-                    {{ "enableBrowserIntegrationFingerprint" | i18n }}
-                  </label>
+                <div class="form-group">
+                  <div class="checkbox">
+                    <label for="enableBrowserIntegration">
+                      <input
+                        id="enableBrowserIntegration"
+                        type="checkbox"
+                        name="EnableBrowserIntegration"
+                        [(ngModel)]="enableBrowserIntegration"
+                        (change)="saveBrowserIntegration()"
+                      />
+                      {{ "enableBrowserIntegration" | i18n }}
+                    </label>
+                  </div>
+                  <small class="help-block">{{ "enableBrowserIntegrationDesc" | i18n }}</small>
                 </div>
-                <small class="help-block">{{
-                  "enableBrowserIntegrationFingerprintDesc" | i18n
-                }}</small>
+                <div class="form-group">
+                  <div class="checkbox">
+                    <label for="enableBrowserIntegrationFingerprint">
+                      <input
+                        id="enableBrowserIntegrationFingerprint"
+                        type="checkbox"
+                        name="EnableBrowserIntegrationFingerprint"
+                        [(ngModel)]="enableBrowserIntegrationFingerprint"
+                        (change)="saveBrowserIntegrationFingerprint()"
+                        [disabled]="!enableBrowserIntegration"
+                      />
+                      {{ "enableBrowserIntegrationFingerprint" | i18n }}
+                    </label>
+                  </div>
+                  <small class="help-block">{{
+                    "enableBrowserIntegrationFingerprintDesc" | i18n
+                  }}</small>
+                </div>
               </div>
-            </div>
-          </ng-container>
-        </div>
+            </ng-container>
+          </div>
+        </ng-container>
         <div class="box">
           <h2>
             <button

--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -3,278 +3,334 @@
     <div class="modal-content">
       <div class="modal-body form">
         <div class="box">
-          <div class="box-header">
-            {{ "security" | i18n }}
-          </div>
-          <div class="box-content box-content-padded">
-            <app-vault-timeout-input
-              [vaultTimeouts]="vaultTimeouts"
-              [formControl]="vaultTimeout"
-              ngDefaultControl
-            ></app-vault-timeout-input>
-            <div class="form-group">
-              <label>{{ "vaultTimeoutAction" | i18n }}</label>
-              <div class="radio radio-mt-2">
-                <label for="vaultTimeoutActionLock">
-                  <input
-                    type="radio"
-                    name="VaultTimeoutAction"
-                    id="vaultTimeoutActionLock"
-                    value="lock"
-                    [(ngModel)]="vaultTimeoutAction"
-                    (change)="saveVaultTimeoutOptions()"
-                  />
-                  {{ "lock" | i18n }}
-                </label>
+          <h2>
+            <button
+              type="button"
+              class="box-header-expandable"
+              (click)="showSecurity = !showSecurity"
+              [attr.aria-expanded]="showSecurity"
+            >
+              {{ "security" | i18n }}
+              <i *ngIf="!showSecurity" class="fa fa-chevron-down fa-sm icon" aria-hidden="true"></i>
+              <i *ngIf="showSecurity" class="fa fa-chevron-up fa-sm icon" aria-hidden="true"></i>
+            </button>
+          </h2>
+          <ng-container *ngIf="showSecurity">
+            <div class="box-content box-content-padded">
+              <app-vault-timeout-input
+                [vaultTimeouts]="vaultTimeouts"
+                [formControl]="vaultTimeout"
+                ngDefaultControl
+              ></app-vault-timeout-input>
+              <div class="form-group">
+                <label>{{ "vaultTimeoutAction" | i18n }}</label>
+                <div class="radio radio-mt-2">
+                  <label for="vaultTimeoutActionLock">
+                    <input
+                      type="radio"
+                      name="VaultTimeoutAction"
+                      id="vaultTimeoutActionLock"
+                      value="lock"
+                      [(ngModel)]="vaultTimeoutAction"
+                      (change)="saveVaultTimeoutOptions()"
+                    />
+                    {{ "lock" | i18n }}
+                  </label>
+                </div>
+                <small class="help-block">{{ "vaultTimeoutActionLockDesc" | i18n }}</small>
+                <div class="radio">
+                  <label for="vaultTimeoutActionLogOut">
+                    <input
+                      type="radio"
+                      name="VaultTimeoutAction"
+                      id="vaultTimeoutActionLogOut"
+                      value="logOut"
+                      [(ngModel)]="vaultTimeoutAction"
+                      (change)="saveVaultTimeoutOptions()"
+                    />
+                    {{ "logOut" | i18n }}
+                  </label>
+                </div>
+                <small class="help-block">{{ "vaultTimeoutActionLogOutDesc" | i18n }}</small>
               </div>
-              <small class="help-block">{{ "vaultTimeoutActionLockDesc" | i18n }}</small>
-              <div class="radio">
-                <label for="vaultTimeoutActionLogOut">
-                  <input
-                    type="radio"
-                    name="VaultTimeoutAction"
-                    id="vaultTimeoutActionLogOut"
-                    value="logOut"
-                    [(ngModel)]="vaultTimeoutAction"
-                    (change)="saveVaultTimeoutOptions()"
-                  />
-                  {{ "logOut" | i18n }}
-                </label>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="pin">
+                    <input
+                      id="pin"
+                      type="checkbox"
+                      name="PIN"
+                      [(ngModel)]="pin"
+                      (change)="updatePin()"
+                    />
+                    {{ "unlockWithPin" | i18n }}
+                  </label>
+                </div>
               </div>
-              <small class="help-block">{{ "vaultTimeoutActionLogOutDesc" | i18n }}</small>
+              <div class="form-group" *ngIf="supportsBiometric">
+                <div class="checkbox">
+                  <label for="biometric">
+                    <input
+                      id="biometric"
+                      type="checkbox"
+                      name="biometric"
+                      [checked]="biometric"
+                      (change)="updateBiometric()"
+                    />
+                    {{ biometricText | i18n }}
+                  </label>
+                </div>
+              </div>
+              <div class="form-group" *ngIf="supportsBiometric">
+                <div class="checkbox">
+                  <label for="noAutoPromptBiometrics">
+                    <input
+                      id="noAutoPromptBiometrics"
+                      type="checkbox"
+                      name="noAutoPromptBiometrics"
+                      [(ngModel)]="noAutoPromptBiometrics"
+                      [disabled]="!biometric"
+                      (change)="updateNoAutoPromptBiometrics()"
+                    />
+                    {{ noAutoPromptBiometricsText | i18n }}
+                  </label>
+                </div>
+              </div>
             </div>
-            <div class="form-group">
-              <div class="checkbox">
-                <label for="pin">
-                  <input
-                    id="pin"
-                    type="checkbox"
-                    name="PIN"
-                    [(ngModel)]="pin"
-                    (change)="updatePin()"
-                  />
-                  {{ "unlockWithPin" | i18n }}
-                </label>
-              </div>
-            </div>
-            <div class="form-group" *ngIf="supportsBiometric">
-              <div class="checkbox">
-                <label for="biometric">
-                  <input
-                    id="biometric"
-                    type="checkbox"
-                    name="biometric"
-                    [checked]="biometric"
-                    (change)="updateBiometric()"
-                  />
-                  {{ biometricText | i18n }}
-                </label>
-              </div>
-            </div>
-            <div class="form-group" *ngIf="supportsBiometric">
-              <div class="checkbox">
-                <label for="noAutoPromptBiometrics">
-                  <input
-                    id="noAutoPromptBiometrics"
-                    type="checkbox"
-                    name="noAutoPromptBiometrics"
-                    [(ngModel)]="noAutoPromptBiometrics"
-                    [disabled]="!biometric"
-                    (change)="updateNoAutoPromptBiometrics()"
-                  />
-                  {{ noAutoPromptBiometricsText | i18n }}
-                </label>
-              </div>
-            </div>
-          </div>
+          </ng-container>
         </div>
         <div class="box">
-          <div class="box-header">
-            {{ "options" | i18n }}
-          </div>
-          <div class="box-content box-content-padded">
-            <div class="form-group">
-              <label for="clearClipboard">{{ "clearClipboard" | i18n }}</label>
-              <select
-                id="clearClipboard"
-                name="ClearClipboard"
-                [(ngModel)]="clearClipboard"
-                (change)="saveClearClipboard()"
-              >
-                <option *ngFor="let o of clearClipboardOptions" [ngValue]="o.value">
-                  {{ o.name }}
-                </option>
-              </select>
-              <small class="help-block">{{ "clearClipboardDesc" | i18n }}</small>
-            </div>
-            <div class="form-group">
-              <div class="checkbox">
-                <label for="minimizeOnCopyToClipboard">
-                  <input
-                    id="minimizeOnCopyToClipboard"
-                    type="checkbox"
-                    name="MinimizeOnCopyToClipboard"
-                    [(ngModel)]="minimizeOnCopyToClipboard"
-                    (change)="saveMinOnCopyToClipboard()"
-                  />
-                  {{ "minimizeOnCopyToClipboard" | i18n }}
-                </label>
+          <h2>
+            <button
+              type="button"
+              class="box-header-expandable"
+              (click)="showAccountPreferences = !showAccountPreferences"
+              [attr.aria-expanded]="showAccountPreferences"
+            >
+              {{ "accountPreferences" | i18n }}
+              <i
+                *ngIf="!showAccountPreferences"
+                class="fa fa-chevron-down fa-sm icon"
+                aria-hidden="true"
+              ></i>
+              <i
+                *ngIf="showAccountPreferences"
+                class="fa fa-chevron-up fa-sm icon"
+                aria-hidden="true"
+              ></i>
+            </button>
+          </h2>
+          <ng-container *ngIf="showAccountPreferences">
+            <div class="box-content box-content-padded">
+              <div class="form-group">
+                <label for="clearClipboard">{{ "clearClipboard" | i18n }}</label>
+                <select
+                  id="clearClipboard"
+                  name="ClearClipboard"
+                  [(ngModel)]="clearClipboard"
+                  (change)="saveClearClipboard()"
+                >
+                  <option *ngFor="let o of clearClipboardOptions" [ngValue]="o.value">
+                    {{ o.name }}
+                  </option>
+                </select>
+                <small class="help-block">{{ "clearClipboardDesc" | i18n }}</small>
               </div>
-              <small class="help-block">{{ "minimizeOnCopyToClipboardDesc" | i18n }}</small>
-            </div>
-            <div class="form-group">
-              <div class="checkbox">
-                <label for="disableFavicons">
-                  <input
-                    id="disableFavicons"
-                    type="checkbox"
-                    name="DisableFavicons"
-                    [(ngModel)]="disableFavicons"
-                    (change)="saveFavicons()"
-                  />
-                  {{ "disableFavicon" | i18n }}
-                </label>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="minimizeOnCopyToClipboard">
+                    <input
+                      id="minimizeOnCopyToClipboard"
+                      type="checkbox"
+                      name="MinimizeOnCopyToClipboard"
+                      [(ngModel)]="minimizeOnCopyToClipboard"
+                      (change)="saveMinOnCopyToClipboard()"
+                    />
+                    {{ "minimizeOnCopyToClipboard" | i18n }}
+                  </label>
+                </div>
+                <small class="help-block">{{ "minimizeOnCopyToClipboardDesc" | i18n }}</small>
               </div>
-              <small class="help-block">{{ "disableFaviconDesc" | i18n }}</small>
-            </div>
-            <div class="form-group">
-              <div class="checkbox">
-                <label for="enableBrowserIntegration">
-                  <input
-                    id="enableBrowserIntegration"
-                    type="checkbox"
-                    name="EnableBrowserIntegration"
-                    [(ngModel)]="enableBrowserIntegration"
-                    (change)="saveBrowserIntegration()"
-                  />
-                  {{ "enableBrowserIntegration" | i18n }}
-                </label>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="disableFavicons">
+                    <input
+                      id="disableFavicons"
+                      type="checkbox"
+                      name="DisableFavicons"
+                      [(ngModel)]="disableFavicons"
+                      (change)="saveFavicons()"
+                    />
+                    {{ "disableFavicon" | i18n }}
+                  </label>
+                </div>
+                <small class="help-block">{{ "disableFaviconDesc" | i18n }}</small>
               </div>
-              <small class="help-block">{{ "enableBrowserIntegrationDesc" | i18n }}</small>
-            </div>
-            <div class="form-group">
-              <div class="checkbox">
-                <label for="enableBrowserIntegrationFingerprint">
-                  <input
-                    id="enableBrowserIntegrationFingerprint"
-                    type="checkbox"
-                    name="EnableBrowserIntegrationFingerprint"
-                    [(ngModel)]="enableBrowserIntegrationFingerprint"
-                    (change)="saveBrowserIntegrationFingerprint()"
-                    [disabled]="!enableBrowserIntegration"
-                  />
-                  {{ "enableBrowserIntegrationFingerprint" | i18n }}
-                </label>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="enableBrowserIntegration">
+                    <input
+                      id="enableBrowserIntegration"
+                      type="checkbox"
+                      name="EnableBrowserIntegration"
+                      [(ngModel)]="enableBrowserIntegration"
+                      (change)="saveBrowserIntegration()"
+                    />
+                    {{ "enableBrowserIntegration" | i18n }}
+                  </label>
+                </div>
+                <small class="help-block">{{ "enableBrowserIntegrationDesc" | i18n }}</small>
               </div>
-              <small class="help-block">{{
-                "enableBrowserIntegrationFingerprintDesc" | i18n
-              }}</small>
-            </div>
-            <div class="form-group">
-              <div class="checkbox">
-                <label for="enableTray">
-                  <input
-                    id="enableTray"
-                    type="checkbox"
-                    name="EnableTray"
-                    [(ngModel)]="enableTray"
-                    (change)="saveTray()"
-                  />
-                  {{ enableTrayText }}
-                </label>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="enableBrowserIntegrationFingerprint">
+                    <input
+                      id="enableBrowserIntegrationFingerprint"
+                      type="checkbox"
+                      name="EnableBrowserIntegrationFingerprint"
+                      [(ngModel)]="enableBrowserIntegrationFingerprint"
+                      (change)="saveBrowserIntegrationFingerprint()"
+                      [disabled]="!enableBrowserIntegration"
+                    />
+                    {{ "enableBrowserIntegrationFingerprint" | i18n }}
+                  </label>
+                </div>
+                <small class="help-block">{{
+                  "enableBrowserIntegrationFingerprintDesc" | i18n
+                }}</small>
               </div>
-              <small class="help-block">{{ enableTrayDescText }}</small>
             </div>
-            <div class="form-group" *ngIf="showMinToTray">
-              <div class="checkbox">
-                <label for="enableMinToTray">
-                  <input
-                    id="enableMinToTray"
-                    type="checkbox"
-                    name="EnableMinToTray"
-                    [(ngModel)]="enableMinToTray"
-                    (change)="saveMinToTray()"
-                  />
-                  {{ enableMinToTrayText }}
-                </label>
+          </ng-container>
+        </div>
+        <div class="box">
+          <h2>
+            <button
+              type="button"
+              class="box-header-expandable"
+              (click)="showAppPreferences = !showAppPreferences"
+              [attr.aria-expanded]="showAppPreferences"
+            >
+              {{ "appPreferences" | i18n }}
+              <i
+                *ngIf="!showAppPreferences"
+                class="fa fa-chevron-down fa-sm icon"
+                aria-hidden="true"
+              ></i>
+              <i
+                *ngIf="showAppPreferences"
+                class="fa fa-chevron-up fa-sm icon"
+                aria-hidden="true"
+              ></i>
+            </button>
+          </h2>
+          <ng-container *ngIf="showAppPreferences">
+            <div class="box-content box-content-padded">
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="enableTray">
+                    <input
+                      id="enableTray"
+                      type="checkbox"
+                      name="EnableTray"
+                      [(ngModel)]="enableTray"
+                      (change)="saveTray()"
+                    />
+                    {{ enableTrayText }}
+                  </label>
+                </div>
+                <small class="help-block">{{ enableTrayDescText }}</small>
               </div>
-              <small class="help-block">{{ enableMinToTrayDescText }}</small>
-            </div>
-            <div class="form-group">
-              <div class="checkbox">
-                <label for="enableCloseToTray">
-                  <input
-                    id="enableCloseToTray"
-                    type="checkbox"
-                    name="EnableCloseToTray"
-                    [(ngModel)]="enableCloseToTray"
-                    (change)="saveCloseToTray()"
-                  />
-                  {{ enableCloseToTrayText }}
-                </label>
+              <div class="form-group" *ngIf="showMinToTray">
+                <div class="checkbox">
+                  <label for="enableMinToTray">
+                    <input
+                      id="enableMinToTray"
+                      type="checkbox"
+                      name="EnableMinToTray"
+                      [(ngModel)]="enableMinToTray"
+                      (change)="saveMinToTray()"
+                    />
+                    {{ enableMinToTrayText }}
+                  </label>
+                </div>
+                <small class="help-block">{{ enableMinToTrayDescText }}</small>
               </div>
-              <small class="help-block">{{ enableCloseToTrayDescText }}</small>
-            </div>
-            <div class="form-group">
-              <div class="checkbox">
-                <label for="startToTray">
-                  <input
-                    id="startToTray"
-                    type="checkbox"
-                    name="StartToTray"
-                    [(ngModel)]="startToTray"
-                    (change)="saveStartToTray()"
-                  />
-                  {{ startToTrayText }}
-                </label>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="enableCloseToTray">
+                    <input
+                      id="enableCloseToTray"
+                      type="checkbox"
+                      name="EnableCloseToTray"
+                      [(ngModel)]="enableCloseToTray"
+                      (change)="saveCloseToTray()"
+                    />
+                    {{ enableCloseToTrayText }}
+                  </label>
+                </div>
+                <small class="help-block">{{ enableCloseToTrayDescText }}</small>
               </div>
-              <small class="help-block">{{ startToTrayDescText }}</small>
-            </div>
-            <div class="form-group">
-              <div class="checkbox">
-                <label for="openAtLogin">
-                  <input
-                    id="openAtLogin"
-                    type="checkbox"
-                    name="OpenAtLogin"
-                    [(ngModel)]="openAtLogin"
-                    (change)="saveOpenAtLogin()"
-                  />
-                  {{ "openAtLogin" | i18n }}
-                </label>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="startToTray">
+                    <input
+                      id="startToTray"
+                      type="checkbox"
+                      name="StartToTray"
+                      [(ngModel)]="startToTray"
+                      (change)="saveStartToTray()"
+                    />
+                    {{ startToTrayText }}
+                  </label>
+                </div>
+                <small class="help-block">{{ startToTrayDescText }}</small>
               </div>
-              <small class="help-block">{{ "openAtLoginDesc" | i18n }}</small>
-            </div>
-            <div class="form-group" *ngIf="showAlwaysShowDock">
-              <div class="checkbox">
-                <label for="alwaysShowDock">
-                  <input
-                    id="alwaysShowDock"
-                    type="checkbox"
-                    name="AlwaysShowDock"
-                    [(ngModel)]="alwaysShowDock"
-                    (change)="saveAlwaysShowDock()"
-                  />
-                  {{ "alwaysShowDock" | i18n }}
-                </label>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="openAtLogin">
+                    <input
+                      id="openAtLogin"
+                      type="checkbox"
+                      name="OpenAtLogin"
+                      [(ngModel)]="openAtLogin"
+                      (change)="saveOpenAtLogin()"
+                    />
+                    {{ "openAtLogin" | i18n }}
+                  </label>
+                </div>
+                <small class="help-block">{{ "openAtLoginDesc" | i18n }}</small>
               </div>
-              <small class="help-block">{{ "alwaysShowDockDesc" | i18n }}</small>
+              <div class="form-group" *ngIf="showAlwaysShowDock">
+                <div class="checkbox">
+                  <label for="alwaysShowDock">
+                    <input
+                      id="alwaysShowDock"
+                      type="checkbox"
+                      name="AlwaysShowDock"
+                      [(ngModel)]="alwaysShowDock"
+                      (change)="saveAlwaysShowDock()"
+                    />
+                    {{ "alwaysShowDock" | i18n }}
+                  </label>
+                </div>
+                <small class="help-block">{{ "alwaysShowDockDesc" | i18n }}</small>
+              </div>
+              <div class="form-group">
+                <label for="theme">{{ "theme" | i18n }}</label>
+                <select id="theme" name="Theme" [(ngModel)]="theme" (change)="saveTheme()">
+                  <option *ngFor="let o of themeOptions" [ngValue]="o.value">{{ o.name }}</option>
+                </select>
+                <small class="help-block">{{ "themeDesc" | i18n }}</small>
+              </div>
+              <div class="form-group">
+                <label for="locale">{{ "language" | i18n }}</label>
+                <select id="locale" name="Locale" [(ngModel)]="locale" (change)="saveLocale()">
+                  <option *ngFor="let o of localeOptions" [ngValue]="o.value">{{ o.name }}</option>
+                </select>
+                <small class="help-block">{{ "languageDesc" | i18n }}</small>
+              </div>
             </div>
-            <div class="form-group">
-              <label for="theme">{{ "theme" | i18n }}</label>
-              <select id="theme" name="Theme" [(ngModel)]="theme" (change)="saveTheme()">
-                <option *ngFor="let o of themeOptions" [ngValue]="o.value">{{ o.name }}</option>
-              </select>
-              <small class="help-block">{{ "themeDesc" | i18n }}</small>
-            </div>
-            <div class="form-group">
-              <label for="locale">{{ "language" | i18n }}</label>
-              <select id="locale" name="Locale" [(ngModel)]="locale" (change)="saveLocale()">
-                <option *ngFor="let o of localeOptions" [ngValue]="o.value">{{ o.name }}</option>
-              </select>
-              <small class="help-block">{{ "languageDesc" | i18n }}</small>
-            </div>
-          </div>
+          </ng-container>
         </div>
       </div>
       <div class="modal-footer">

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -65,6 +65,10 @@ export class SettingsComponent implements OnInit {
 
   vaultTimeout: FormControl = new FormControl(null);
 
+  showSecurity: boolean = true;
+  showAccountPreferences: boolean = true;
+  showAppPreferences: boolean = true;
+
   constructor(
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -69,7 +69,7 @@ export class SettingsComponent implements OnInit {
   showAccountPreferences: boolean = true;
   showAppPreferences: boolean = true;
 
-  currentUserId: string;
+  currentUserEmail: string;
 
   constructor(
     private i18nService: I18nService,
@@ -171,10 +171,10 @@ export class SettingsComponent implements OnInit {
     this.locale = await this.stateService.getLocale();
     this.theme = await this.stateService.getTheme();
 
-    this.currentUserId = await this.stateService.getUserId();
-    if (this.currentUserId == null) {
+    if ((await this.stateService.getUserId()) == null) {
       return;
     }
+    this.currentUserEmail = await this.stateService.getEmail();
 
     // Security
     this.vaultTimeout.setValue(await this.stateService.getVaultTimeout());

--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -69,6 +69,8 @@ export class SettingsComponent implements OnInit {
   showAccountPreferences: boolean = true;
   showAppPreferences: boolean = true;
 
+  currentUserId: string;
+
   constructor(
     private i18nService: I18nService,
     private platformUtilsService: PlatformUtilsService,
@@ -155,21 +157,36 @@ export class SettingsComponent implements OnInit {
   }
 
   async ngOnInit() {
+    // App preferences
     this.showMinToTray = this.platformUtilsService.getDevice() !== DeviceType.LinuxDesktop;
-    this.vaultTimeout.setValue(await this.stateService.getVaultTimeout());
-    this.vaultTimeoutAction = await this.stateService.getVaultTimeoutAction();
-    const pinSet = await this.vaultTimeoutService.isPinLockSet();
-    this.pin = pinSet[0] || pinSet[1];
-    this.disableFavicons = await this.stateService.getDisableFavicon();
-    this.enableBrowserIntegration = await this.stateService.getEnableBrowserIntegration();
-    this.enableBrowserIntegrationFingerprint =
-      await this.stateService.getEnableBrowserIntegrationFingerprint();
     this.enableMinToTray = await this.stateService.getEnableMinimizeToTray();
     this.enableCloseToTray = await this.stateService.getEnableCloseToTray();
     this.enableTray = await this.stateService.getEnableTray();
     this.startToTray = await this.stateService.getEnableStartToTray();
+
+    this.alwaysShowDock = await this.stateService.getAlwaysShowDock();
+    this.showAlwaysShowDock = this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop;
+    this.openAtLogin = await this.stateService.getOpenAtLogin();
+
     this.locale = await this.stateService.getLocale();
     this.theme = await this.stateService.getTheme();
+
+    this.currentUserId = await this.stateService.getUserId();
+    if (this.currentUserId == null) {
+      return;
+    }
+
+    // Security
+    this.vaultTimeout.setValue(await this.stateService.getVaultTimeout());
+    this.vaultTimeoutAction = await this.stateService.getVaultTimeoutAction();
+    const pinSet = await this.vaultTimeoutService.isPinLockSet();
+    this.pin = pinSet[0] || pinSet[1];
+
+    // Account preferences
+    this.disableFavicons = await this.stateService.getDisableFavicon();
+    this.enableBrowserIntegration = await this.stateService.getEnableBrowserIntegration();
+    this.enableBrowserIntegrationFingerprint =
+      await this.stateService.getEnableBrowserIntegrationFingerprint();
     this.clearClipboard = await this.stateService.getClearClipboard();
     this.minimizeOnCopyToClipboard = await this.stateService.getMinimizeOnCopyToClipboard();
     this.supportsBiometric = await this.platformUtilsService.supportsBiometric();
@@ -177,9 +194,6 @@ export class SettingsComponent implements OnInit {
     this.biometricText = await this.stateService.getBiometricText();
     this.noAutoPromptBiometrics = await this.stateService.getNoAutoPromptBiometrics();
     this.noAutoPromptBiometricsText = await this.stateService.getNoAutoPromptBiometricsText();
-    this.alwaysShowDock = await this.stateService.getAlwaysShowDock();
-    this.showAlwaysShowDock = this.platformUtilsService.getDevice() === DeviceType.MacOsDesktop;
-    this.openAtLogin = await this.stateService.getOpenAtLogin();
   }
 
   async saveVaultTimeoutOptions() {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -457,9 +457,6 @@
   "updateKey": {
     "message": "You cannot use this feature until you update your encryption key."
   },
-  "options": {
-    "message": "Options"
-  },
   "editedFolder": {
     "message": "Edited folder"
   },
@@ -1792,5 +1789,11 @@
   },
   "accountLimitReached": {
     "message": "No more than 5 accounts may be logged in at the same time."
+  },
+  "accountPreferences": {
+    "message": "Account Preferences"
+  },
+  "appPreferences": {
+    "message": "App Preferences"
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1798,5 +1798,14 @@
   },
   "accountSwitcherLimitReached": {
     "message": "Account limit reached. Log out of an account to add another."
+  },
+  "settingsTitle": {
+    "message": "App settings for $EMAIL$",
+    "placeholders": {
+      "email": {
+        "content": "$1",
+        "example": "jdoe@example.com"
+      }
+    }
   }
 }

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1791,10 +1791,10 @@
     "message": "No more than 5 accounts may be logged in at the same time."
   },
   "accountPreferences": {
-    "message": "Account Preferences"
+    "message": "Preferences"
   },
   "appPreferences": {
-    "message": "App Preferences"
+    "message": "App Settings (All Accounts)"
   },
   "accountSwitcherLimitReached": {
     "message": "Account limit reached. Log out of an account to add another."

--- a/src/scss/box.scss
+++ b/src/scss/box.scss
@@ -34,7 +34,8 @@
   }
 
   .box-header-expandable {
-    padding: 0 10px;
+    border: none;
+    padding: 5px 10px;
     text-transform: uppercase;
     display: flex;
     width: 100%;

--- a/src/scss/box.scss
+++ b/src/scss/box.scss
@@ -4,6 +4,15 @@
   position: relative;
   width: 100%;
 
+  .settingsTitle {
+    margin: 0 10px 5px 10px;
+    display: flex;
+
+    @include themify($themes) {
+      color: themed("headingColor");
+    }
+  }
+
   .box-header {
     margin: 0 10px 5px 10px;
     text-transform: uppercase;
@@ -35,7 +44,7 @@
 
   .box-header-expandable {
     border: none;
-    padding: 5px 10px;
+    padding: 5px 0px;
     text-transform: uppercase;
     display: flex;
     width: 100%;
@@ -43,6 +52,7 @@
 
     @include themify($themes) {
       color: themed("headingColor");
+      background-color: themed("boxBackgroundColor");
     }
 
     &:hover,

--- a/src/scss/box.scss
+++ b/src/scss/box.scss
@@ -33,6 +33,36 @@
     }
   }
 
+  .box-header-expandable {
+    padding: 0 10px;
+    text-transform: uppercase;
+    display: flex;
+    width: 100%;
+    box-sizing: border-box;
+
+    @include themify($themes) {
+      color: themed("headingColor");
+    }
+
+    &:hover,
+    &:focus,
+    &.active {
+      @include themify($themes) {
+        background-color: themed("boxBackgroundHoverColor");
+      }
+    }
+
+    .icon {
+      display: flex;
+      align-items: flex-end;
+      margin-left: 5px;
+
+      @include themify($themes) {
+        color: themed("headingColor");
+      }
+    }
+  }
+
   .box-content {
     border-radius: $border-radius;
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 3px 1px -2px rgba(0, 0, 0, 0.12),


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Split up the options in the settings menu into Security, Account Preferences,  and App Preferences"
Headers should be accessible and announced when expanded

Account specific settings are only shown when a user is authenticated

Details can be found on the Figma spec attached to the Asana ticket: https://app.asana.com/0/1201648796371593/1201665881786823/f

## Code changes
- **src/app/accounts/settings.component.html:** 
  - Split up the menu items into `Security`, `Account Preferences` and `App Preferences`
  - Added accessible box-header for the headers with announement of `aria-expanded`
- **src/app/accounts/settings.component.ts:** Added booleans to control `aria-expanded`
- **src/scss/box.scss:** Add `.box-header-expandable` style, taken from browser - thanks to @patrickhlauke
- **src/locales/en/messages.json:** Add new labels for the settings dropdowns

## Screenshots
- **BEFORE:**
![image](https://user-images.githubusercontent.com/2670567/149821792-19efd8cc-ad6e-41ae-a2f4-7ba7a68cc25a.png)

- **AFTER:**
![image](https://user-images.githubusercontent.com/2670567/150422507-307f712e-1715-4d2a-aec7-720195bcc0cd.png)

## Testing requirements
No functional changes were made - should align with the Figma spec
Expanding and collapsing the settings headers should announce there state through a screen reader

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
