### PR TITLE
[bug] Remove old mac-bar styling

### DIFF
--- a/src/app/send/send.component.html
+++ b/src/app/send/send.component.html
@@ -1,6 +1,5 @@
 <div id="sends" class="vault">
   <div class="groupings">
-    <div class="mac-bar"></div>
     <div class="content">
       <div class="inner-content">
         <h2 class="sr-only">{{ "filters" | i18n }}</h2>

--- a/src/app/vault/groupings.component.html
+++ b/src/app/vault/groupings.component.html
@@ -1,4 +1,3 @@
-<div class="mac-bar"></div>
 <div class="content">
   <div class="inner-content">
     <h2 class="sr-only">{{ "filters" | i18n }}</h2>

--- a/src/scss/environment.scss
+++ b/src/scss/environment.scss
@@ -59,11 +59,6 @@ html.os_macos {
     }
   }
 
-  .vault .mac-bar {
-    height: 48px;
-    -webkit-app-region: drag;
-  }
-
   .vault > .groupings > .content > .inner-content {
     padding-top: 0;
   }


### PR DESCRIPTION


## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
With the account switching work a header was added to the desktop app that new acts as a home for the mac window controls.
Previously we needed a special home for these controls, but since moving them we are not just creating empty space.
Removing this class and the divs that use it corrects the behavior.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Screenshots
![Screen Shot 2022-01-19 at 9 21 18 PM](https://user-images.githubusercontent.com/15897251/150259670-aed15031-e126-4cfa-8f1b-39e7208919eb.png)

## Before you submit
- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
