### PR TITLE
Remove account switching border

### DIFF
--- a/src/scss/environment.scss
+++ b/src/scss/environment.scss
@@ -1,14 +1,4 @@
-﻿html.os_windows {
-  body {
-    border-top: 1px solid #dddddd;
-  }
-
-  &.theme_dark body {
-    border-top-color: #000000;
-  }
-}
-
-html.os_macos {
+﻿html.os_macos {
   body.layout_frontend {
     -webkit-app-region: drag;
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Remove top border on windows, which conflicts with the account switching ui, especially when using a dark os theme and light bitwarden theme.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Before:
![image](https://user-images.githubusercontent.com/137855/150372093-3ef107ea-4963-4531-ab70-630f6ce3aa7d.png)

After:
![image](https://user-images.githubusercontent.com/137855/150372016-1aad0b46-4a4d-4e2d-89a5-101406a43597.png)

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
