### PR TITLE
Move KeyConnector call from client to syncService

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -322,7 +322,6 @@ export class AppComponent implements OnInit {
             }
             break;
           case "convertAccountToKeyConnector":
-            await this.keyConnectorService.setConvertAccountRequired(true);
             this.router.navigate(["/remove-password"]);
             break;
           case "switchAccount":


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Follow on from the jslib update here, which this client is already using: https://github.com/bitwarden/jslib/pull/616

We moved the call to `keyConnectorService.setConvertAccountRequired` into `syncService`, therefore we can remove it from the message event handler in each client.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

Basic regression testing around a user being prompted to convert their account to Key Connector (removing their master password)

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
