### PR TITLE
[Account switching] Fix display of account limit

### DIFF
--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -66,12 +66,12 @@
       </a>
     </div>
     <div class="border"></div>
-    <ng-container *ngIf="numberOfAccounts < 5">
+    <ng-container *ngIf="numberOfAccounts < 4">
       <a class="add" routerLink="/login" (click)="toggle()">
         <i class="fa fa-plus" aria-hidden="true"></i> {{ "addAccount" | i18n }}
       </a>
     </ng-container>
-    <ng-container *ngIf="numberOfAccounts == 5">
+    <ng-container *ngIf="numberOfAccounts == 4">
       <a class="accountLimitReached">{{ "accountSwitcherLimitReached" | i18n }} </a>
     </ng-container>
   </div>


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
As we removed the active account from the dropdown list, the condition to display that the account limit has reached, wasn't working anymore. 

Asana task: https://app.asana.com/0/1201648796371593/1201665881786820/f
## Code changes

- **src/app/layout/account-switcher.component.html:** Fixed the display of the account limit info

## Testing requirements
- The add account button should be shown when no more than 5 accounts (that includes the account at the top of the switcher) are authenticated.
- When 5 accounts are authenticated the button should change to display that the user has reached the account limit and needs to log out of one to login with a new one.

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
