### PR TITLE
Hide account switcher border if no accounts

### DIFF
--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -32,41 +32,39 @@
   cdkConnectedOverlayMinWidth="250px"
 >
   <div class="account-switcher-dropdown" [@transformPanel]="'open'">
-    <ng-container *ngIf="numberOfAccounts > 0">
-      <div class="accounts">
-        <a
-          *ngFor="let a of accounts | keyvalue"
-          class="account"
-          [ngClass]="{ active: a.value.profile.authenticationStatus == 'active' }"
-          href="#"
-          (mousedown)="switch(a.key)"
-        >
-          <app-avatar
-            [data]="a.value.profile.email"
-            size="25"
-            [circle]="true"
-            [fontSize]="14"
-            [dynamic]="true"
-            *ngIf="a.value.profile.email != null"
-          ></app-avatar>
-          <div class="accountInfo">
-            <span class="email">{{ a.value.profile.email }}</span>
-            <span class="server" *ngIf="a.value.serverUrl != 'bitwarden.com'">{{
-              a.value.serverUrl
-            }}</span>
-            <span class="status">{{ a.value.profile.authenticationStatus }}</span>
-          </div>
-          <i
-            class="fa fa-unlock fa-2x text-muted"
-            *ngIf="a.value.profile.authenticationStatus == 'unlocked'"
-          ></i>
-          <i
-            class="fa fa-lock fa-2x text-muted"
-            *ngIf="a.value.profile.authenticationStatus == 'locked'"
-          ></i>
-        </a>
-      </div>
-    </ng-container>
+    <div class="accounts" *ngIf="numberOfAccounts > 0">
+      <a
+        *ngFor="let a of accounts | keyvalue"
+        class="account"
+        [ngClass]="{ active: a.value.profile.authenticationStatus == 'active' }"
+        href="#"
+        (mousedown)="switch(a.key)"
+      >
+        <app-avatar
+          [data]="a.value.profile.email"
+          size="25"
+          [circle]="true"
+          [fontSize]="14"
+          [dynamic]="true"
+          *ngIf="a.value.profile.email != null"
+        ></app-avatar>
+        <div class="accountInfo">
+          <span class="email">{{ a.value.profile.email }}</span>
+          <span class="server" *ngIf="a.value.serverUrl != 'bitwarden.com'">{{
+            a.value.serverUrl
+          }}</span>
+          <span class="status">{{ a.value.profile.authenticationStatus }}</span>
+        </div>
+        <i
+          class="fa fa-unlock fa-2x text-muted"
+          *ngIf="a.value.profile.authenticationStatus == 'unlocked'"
+        ></i>
+        <i
+          class="fa fa-lock fa-2x text-muted"
+          *ngIf="a.value.profile.authenticationStatus == 'locked'"
+        ></i>
+      </a>
+    </div>
     <div class="border" *ngIf="numberOfAccounts < 4 && numberOfAccounts > 0"></div>
     <ng-container *ngIf="numberOfAccounts < 4">
       <a class="add" routerLink="/login" (click)="toggle()">

--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -65,7 +65,7 @@
         ></i>
       </a>
     </div>
-    <div class="border" *ngIf="numberOfAccounts < 4 && numberOfAccounts > 0"></div>
+    <div class="border" *ngIf="numberOfAccounts > 0"></div>
     <ng-container *ngIf="numberOfAccounts < 4">
       <a class="add" routerLink="/login" (click)="toggle()">
         <i class="fa fa-plus" aria-hidden="true"></i> {{ "addAccount" | i18n }}

--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -32,40 +32,42 @@
   cdkConnectedOverlayMinWidth="250px"
 >
   <div class="account-switcher-dropdown" [@transformPanel]="'open'">
-    <div class="accounts">
-      <a
-        *ngFor="let a of accounts | keyvalue"
-        class="account"
-        [ngClass]="{ active: a.value.profile.authenticationStatus == 'active' }"
-        href="#"
-        (mousedown)="switch(a.key)"
-      >
-        <app-avatar
-          [data]="a.value.profile.email"
-          size="25"
-          [circle]="true"
-          [fontSize]="14"
-          [dynamic]="true"
-          *ngIf="a.value.profile.email != null"
-        ></app-avatar>
-        <div class="accountInfo">
-          <span class="email">{{ a.value.profile.email }}</span>
-          <span class="server" *ngIf="a.value.serverUrl != 'bitwarden.com'">{{
-            a.value.serverUrl
-          }}</span>
-          <span class="status">{{ a.value.profile.authenticationStatus }}</span>
-        </div>
-        <i
-          class="fa fa-unlock fa-2x text-muted"
-          *ngIf="a.value.profile.authenticationStatus == 'unlocked'"
-        ></i>
-        <i
-          class="fa fa-lock fa-2x text-muted"
-          *ngIf="a.value.profile.authenticationStatus == 'locked'"
-        ></i>
-      </a>
-    </div>
-    <div class="border"></div>
+    <ng-container *ngIf="numberOfAccounts > 0">
+      <div class="accounts">
+        <a
+          *ngFor="let a of accounts | keyvalue"
+          class="account"
+          [ngClass]="{ active: a.value.profile.authenticationStatus == 'active' }"
+          href="#"
+          (mousedown)="switch(a.key)"
+        >
+          <app-avatar
+            [data]="a.value.profile.email"
+            size="25"
+            [circle]="true"
+            [fontSize]="14"
+            [dynamic]="true"
+            *ngIf="a.value.profile.email != null"
+          ></app-avatar>
+          <div class="accountInfo">
+            <span class="email">{{ a.value.profile.email }}</span>
+            <span class="server" *ngIf="a.value.serverUrl != 'bitwarden.com'">{{
+              a.value.serverUrl
+            }}</span>
+            <span class="status">{{ a.value.profile.authenticationStatus }}</span>
+          </div>
+          <i
+            class="fa fa-unlock fa-2x text-muted"
+            *ngIf="a.value.profile.authenticationStatus == 'unlocked'"
+          ></i>
+          <i
+            class="fa fa-lock fa-2x text-muted"
+            *ngIf="a.value.profile.authenticationStatus == 'locked'"
+          ></i>
+        </a>
+      </div>
+    </ng-container>
+    <div class="border" *ngIf="numberOfAccounts < 4 && numberOfAccounts > 0"></div>
     <ng-container *ngIf="numberOfAccounts < 4">
       <a class="add" routerLink="/login" (click)="toggle()">
         <i class="fa fa-plus" aria-hidden="true"></i> {{ "addAccount" | i18n }}


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Hides the border in the account switcher if there are no accounts to switch between, or we are unable to add more.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

Before:
![image](https://user-images.githubusercontent.com/137855/150538147-5ef66dce-7067-410f-b736-23ab021c30c4.png)

After:
![image](https://user-images.githubusercontent.com/137855/150538032-4f2e79be-354c-4fcb-a270-10e3e21f1765.png)

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
