### PR TITLE
[bug] Correct DI setup for SystemService

### DIFF
--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -159,13 +159,12 @@ export function initFactory(
     },
     {
       provide: SystemServiceAbstraction,
-      useClass: SystemService,
-      deps: [
-        VaultTimeoutServiceAbstraction,
-        MessagingServiceAbstraction,
-        PlatformUtilsServiceAbstraction,
-        StateServiceAbstraction,
-      ],
+      useFactory: (
+        messagingService: MessagingServiceAbstraction,
+        platformUtilsService: PlatformUtilsServiceAbstraction,
+        stateService: StateServiceAbstraction
+      ) => new SystemService(messagingService, platformUtilsService, null, stateService),
+      deps: [MessagingServiceAbstraction, PlatformUtilsServiceAbstraction, StateServiceAbstraction],
     },
     { provide: PasswordRepromptServiceAbstraction, useClass: PasswordRepromptService },
     NativeMessagingService,


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The DI refactor created a bad initializer for SystemService that left out the reload callback.
This causes clipboard clearing to not function, as platformUtilsService was not correctly injected.

## Before you submit
* This callback is null in prod, so I just set up a factory initializer that used null for the callback value. 
* I also removed the vaultTimeoutService dependency from SystemService DI, as that reference has been replaced with StateService.
* I also updated jslib, no relevant changes

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
