### PR TITLE
Unset active account when adding additional accounts

### DIFF
--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -5,15 +5,20 @@
   #trigger="cdkOverlayOrigin"
   [hidden]="!showSwitcher"
 >
-  <app-avatar
-    [data]="activeAccountEmail"
-    size="25"
-    [circle]="true"
-    [fontSize]="14"
-    [dynamic]="true"
-    *ngIf="activeAccountEmail != null"
-  ></app-avatar>
-  <span>{{ activeAccountEmail }}</span>
+  <ng-container *ngIf="activeAccountEmail != null; else noActiveAccount">
+    <app-avatar
+      [data]="activeAccountEmail"
+      size="25"
+      [circle]="true"
+      [fontSize]="14"
+      [dynamic]="true"
+      *ngIf="activeAccountEmail != null"
+    ></app-avatar>
+    <span>{{ activeAccountEmail }}</span>
+  </ng-container>
+  <ng-template #noActiveAccount>
+    <span>{{ "switchAccount" | i18n }}</span>
+  </ng-template>
   <i
     class="fa"
     aria-hidden="true"
@@ -65,14 +70,16 @@
         ></i>
       </a>
     </div>
-    <div class="border" *ngIf="numberOfAccounts > 0"></div>
-    <ng-container *ngIf="numberOfAccounts < 4">
-      <a class="add" routerLink="/login" (click)="toggle()">
-        <i class="fa fa-plus" aria-hidden="true"></i> {{ "addAccount" | i18n }}
-      </a>
-    </ng-container>
-    <ng-container *ngIf="numberOfAccounts == 4">
-      <span class="accountLimitReached">{{ "accountSwitcherLimitReached" | i18n }} </span>
+    <ng-container *ngIf="activeAccountEmail != null">
+      <div class="border" *ngIf="numberOfAccounts > 0"></div>
+      <ng-container *ngIf="numberOfAccounts < 4">
+        <a class="add" routerLink="/login" (click)="addAccount()">
+          <i class="fa fa-plus" aria-hidden="true"></i> {{ "addAccount" | i18n }}
+        </a>
+      </ng-container>
+      <ng-container *ngIf="numberOfAccounts == 4">
+        <span class="accountLimitReached">{{ "accountSwitcherLimitReached" | i18n }} </span>
+      </ng-container>
     </ng-container>
   </div>
 </ng-template>

--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -72,7 +72,7 @@
       </a>
     </ng-container>
     <ng-container *ngIf="numberOfAccounts == 4">
-      <a class="accountLimitReached">{{ "accountSwitcherLimitReached" | i18n }} </a>
+      <span class="accountLimitReached">{{ "accountSwitcherLimitReached" | i18n }} </span>
     </ng-container>
   </div>
 </ng-template>

--- a/src/app/layout/account-switcher.component.ts
+++ b/src/app/layout/account-switcher.component.ts
@@ -65,7 +65,9 @@ export class AccountSwitcherComponent implements OnInit {
   ];
 
   get showSwitcher() {
-    return !Utils.isNullOrWhitespace(this.activeAccountEmail);
+    const userIsInAVault = !Utils.isNullOrWhitespace(this.activeAccountEmail);
+    const userIsAddingAnAdditionalAccount = Object.keys(this.accounts).length > 0;
+    return userIsInAVault || userIsAddingAnAdditionalAccount;
   }
 
   get numberOfAccounts() {
@@ -109,6 +111,11 @@ export class AccountSwitcherComponent implements OnInit {
     this.toggle();
 
     this.messagingService.send("switchAccount", { userId: userId });
+  }
+
+  addAccount() {
+    this.toggle();
+    this.stateService.setActiveUser(null);
   }
 
   private async createSwitcherAccounts(baseAccounts: {

--- a/src/app/layout/account-switcher.component.ts
+++ b/src/app/layout/account-switcher.component.ts
@@ -113,9 +113,9 @@ export class AccountSwitcherComponent implements OnInit {
     this.messagingService.send("switchAccount", { userId: userId });
   }
 
-  addAccount() {
+  async addAccount() {
     this.toggle();
-    this.stateService.setActiveUser(null);
+    await this.stateService.setActiveUser(null);
   }
 
   private async createSwitcherAccounts(baseAccounts: {

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1807,5 +1807,8 @@
         "example": "jdoe@example.com"
       }
     }
+  },
+  "switchAccount": {
+    "message": "Switch Account"
   }
 }

--- a/src/scss/header.scss
+++ b/src/scss/header.scss
@@ -176,7 +176,9 @@
   }
 
   .accountLimitReached {
+    display: block;
     margin: 4px 0;
+    padding: 5px 10px;
     font-size: $font-size-small;
   }
 }


### PR DESCRIPTION
## Type of change
- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective
Currently we maintain an active account when adding additional accounts via account switching.
Instead, we would like to unset the active account when adding accounts.

## Code changes
* Kinda unrelated, but I noticed the "Max account limit reached" warning was a link, which gave it a hover effect I don't think we want. I changed this to a span and added the css needed to keep it looking the same as before, just without the hover.
* Unset the active account when clicking "Add account" and redirecting to login.
* Show a "Switch Account" helper text as the account switcher header if no active account is present.
* Hide the "Add account" button or "Max account limit reached" warning if already on the login screen adding an additional account.

## Screenshots
https://user-images.githubusercontent.com/15897251/150654210-6e520fc4-5427-4af0-b2b9-6b892debe657.mov


## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
