### PR TITLE
[bug] Move enableBrowserIntegration to global settings

### DIFF
--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -293,39 +293,39 @@
                 </div>
                 <small class="help-block">{{ "alwaysShowDockDesc" | i18n }}</small>
               </div>
-                <div class="form-group">
-                  <div class="checkbox">
-                    <label for="enableBrowserIntegration">
-                      <input
-                        id="enableBrowserIntegration"
-                        type="checkbox"
-                        name="EnableBrowserIntegration"
-                        [(ngModel)]="enableBrowserIntegration"
-                        (change)="saveBrowserIntegration()"
-                      />
-                      {{ "enableBrowserIntegration" | i18n }}
-                    </label>
-                  </div>
-                  <small class="help-block">{{ "enableBrowserIntegrationDesc" | i18n }}</small>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="enableBrowserIntegration">
+                    <input
+                      id="enableBrowserIntegration"
+                      type="checkbox"
+                      name="EnableBrowserIntegration"
+                      [(ngModel)]="enableBrowserIntegration"
+                      (change)="saveBrowserIntegration()"
+                    />
+                    {{ "enableBrowserIntegration" | i18n }}
+                  </label>
                 </div>
-                <div class="form-group">
-                  <div class="checkbox">
-                    <label for="enableBrowserIntegrationFingerprint">
-                      <input
-                        id="enableBrowserIntegrationFingerprint"
-                        type="checkbox"
-                        name="EnableBrowserIntegrationFingerprint"
-                        [(ngModel)]="enableBrowserIntegrationFingerprint"
-                        (change)="saveBrowserIntegrationFingerprint()"
-                        [disabled]="!enableBrowserIntegration"
-                      />
-                      {{ "enableBrowserIntegrationFingerprint" | i18n }}
-                    </label>
-                  </div>
-                  <small class="help-block">{{
-                    "enableBrowserIntegrationFingerprintDesc" | i18n
-                  }}</small>
+                <small class="help-block">{{ "enableBrowserIntegrationDesc" | i18n }}</small>
+              </div>
+              <div class="form-group">
+                <div class="checkbox">
+                  <label for="enableBrowserIntegrationFingerprint">
+                    <input
+                      id="enableBrowserIntegrationFingerprint"
+                      type="checkbox"
+                      name="EnableBrowserIntegrationFingerprint"
+                      [(ngModel)]="enableBrowserIntegrationFingerprint"
+                      (change)="saveBrowserIntegrationFingerprint()"
+                      [disabled]="!enableBrowserIntegration"
+                    />
+                    {{ "enableBrowserIntegrationFingerprint" | i18n }}
+                  </label>
                 </div>
+                <small class="help-block">{{
+                  "enableBrowserIntegrationFingerprintDesc" | i18n
+                }}</small>
+              </div>
               <div class="form-group">
                 <label for="theme">{{ "theme" | i18n }}</label>
                 <select id="theme" name="Theme" [(ngModel)]="theme" (change)="saveTheme()">

--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -176,39 +176,6 @@
                   </div>
                   <small class="help-block">{{ "disableFaviconDesc" | i18n }}</small>
                 </div>
-                <div class="form-group">
-                  <div class="checkbox">
-                    <label for="enableBrowserIntegration">
-                      <input
-                        id="enableBrowserIntegration"
-                        type="checkbox"
-                        name="EnableBrowserIntegration"
-                        [(ngModel)]="enableBrowserIntegration"
-                        (change)="saveBrowserIntegration()"
-                      />
-                      {{ "enableBrowserIntegration" | i18n }}
-                    </label>
-                  </div>
-                  <small class="help-block">{{ "enableBrowserIntegrationDesc" | i18n }}</small>
-                </div>
-                <div class="form-group">
-                  <div class="checkbox">
-                    <label for="enableBrowserIntegrationFingerprint">
-                      <input
-                        id="enableBrowserIntegrationFingerprint"
-                        type="checkbox"
-                        name="EnableBrowserIntegrationFingerprint"
-                        [(ngModel)]="enableBrowserIntegrationFingerprint"
-                        (change)="saveBrowserIntegrationFingerprint()"
-                        [disabled]="!enableBrowserIntegration"
-                      />
-                      {{ "enableBrowserIntegrationFingerprint" | i18n }}
-                    </label>
-                  </div>
-                  <small class="help-block">{{
-                    "enableBrowserIntegrationFingerprintDesc" | i18n
-                  }}</small>
-                </div>
               </ng-container>
             </div>
           </div>
@@ -326,6 +293,39 @@
                 </div>
                 <small class="help-block">{{ "alwaysShowDockDesc" | i18n }}</small>
               </div>
+                <div class="form-group">
+                  <div class="checkbox">
+                    <label for="enableBrowserIntegration">
+                      <input
+                        id="enableBrowserIntegration"
+                        type="checkbox"
+                        name="EnableBrowserIntegration"
+                        [(ngModel)]="enableBrowserIntegration"
+                        (change)="saveBrowserIntegration()"
+                      />
+                      {{ "enableBrowserIntegration" | i18n }}
+                    </label>
+                  </div>
+                  <small class="help-block">{{ "enableBrowserIntegrationDesc" | i18n }}</small>
+                </div>
+                <div class="form-group">
+                  <div class="checkbox">
+                    <label for="enableBrowserIntegrationFingerprint">
+                      <input
+                        id="enableBrowserIntegrationFingerprint"
+                        type="checkbox"
+                        name="EnableBrowserIntegrationFingerprint"
+                        [(ngModel)]="enableBrowserIntegrationFingerprint"
+                        (change)="saveBrowserIntegrationFingerprint()"
+                        [disabled]="!enableBrowserIntegration"
+                      />
+                      {{ "enableBrowserIntegrationFingerprint" | i18n }}
+                    </label>
+                  </div>
+                  <small class="help-block">{{
+                    "enableBrowserIntegrationFingerprintDesc" | i18n
+                  }}</small>
+                </div>
               <div class="form-group">
                 <label for="theme">{{ "theme" | i18n }}</label>
                 <select id="theme" name="Theme" [(ngModel)]="theme" (change)="saveTheme()">


### PR DESCRIPTION
Depends on https://github.com/bitwarden/jslib/pull/630

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Enable Browser Integration should be a global setting, but currently we have it set at the account level.

## Code changes
* Update the settings template to match the backing data structure set in jslib. This PR just moves fields, it does not modify behavior - that is all in jslib.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
