### PR TITLE
[bug] Don't monitor vault timeout action valueChanges until after init

### DIFF
--- a/src/app/accounts/settings.component.ts
+++ b/src/app/accounts/settings.component.ts
@@ -122,10 +122,6 @@ export class SettingsComponent implements OnInit {
       { name: i18nService.t("never"), value: null },
     ]);
 
-    this.vaultTimeout.valueChanges.pipe(debounceTime(500)).subscribe(() => {
-      this.saveVaultTimeoutOptions();
-    });
-
     const localeOptions: any[] = [];
     i18nService.supportedTranslationLocales.forEach((locale) => {
       let name = locale;
@@ -179,6 +175,10 @@ export class SettingsComponent implements OnInit {
     // Security
     this.vaultTimeout.setValue(await this.stateService.getVaultTimeout());
     this.vaultTimeoutAction = await this.stateService.getVaultTimeoutAction();
+    this.vaultTimeout.valueChanges.pipe(debounceTime(500)).subscribe(() => {
+      this.saveVaultTimeoutOptions();
+    });
+
     const pinSet = await this.vaultTimeoutService.isPinLockSet();
     this.pin = pinSet[0] || pinSet[1];
 


### PR DESCRIPTION
https://app.asana.com/0/1201648796371593/1201718931972231

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Bug
If a vault's timeout action is set to "Logout" we fire a confirmation prompt. Right now, that prompt is coming up every time the settings screen is opened no matter how many times the confirmation is done. The expected result is that a user only has to confirm once, on initial set of the value.


## Code changes
* Move the valueChanges subscription for vault timeout options to start after those values are inited. This stops the popup from happening, because it's firing when we set the value from state.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
