### PR TITLE
[bug] Inactive accounts with power-based timeout settings are not timing out

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -339,6 +339,45 @@ export class AppComponent implements OnInit {
               this.router.navigate(["vault"]);
             }
             break;
+          case "systemSuspended":
+            for (const userId in this.stateService.accounts.getValue()) {
+              if (userId == null) {
+                continue;
+              }
+              const options = await this.getVaultTimeoutOptions(userId);
+              if (options[0] === -3) {
+                options[1] === "logOut"
+                  ? this.messagingService.send("logout", { expired: false, userId: userId })
+                  : this.messagingService.send("lockVault", { userId: userId });
+              }
+            }
+            break;
+          case "systemLocked":
+            for (const userId in this.stateService.accounts.getValue()) {
+              if (userId == null) {
+                continue;
+              }
+              const options = await this.getVaultTimeoutOptions(userId);
+              if (options[0] === -2) {
+                options[1] === "logOut"
+                  ? this.messagingService.send("logout", { expired: false, userId: userId })
+                  : this.messagingService.send("lockVault", { userId: userId });
+              }
+            }
+            break;
+          case "systemIdel":
+            for (const userId in this.stateService.accounts.getValue()) {
+              if (userId == null) {
+                continue;
+              }
+              const options = await this.getVaultTimeoutOptions(userId);
+              if (options[0] === -4) {
+                options[1] === "logOut"
+                  ? this.messagingService.send("logout", { expired: false, userId: userId })
+                  : this.messagingService.send("lockVault", { userId: userId });
+              }
+            }
+            break;
         }
       });
     });
@@ -582,5 +621,11 @@ export class AppComponent implements OnInit {
       }
     }
     await this.systemService.startProcessReload();
+  }
+
+  private async getVaultTimeoutOptions(userId: string): Promise<[number, string]> {
+    const timeout = await this.stateService.getVaultTimeout({ userId: userId });
+    const action = await this.stateService.getVaultTimeoutAction({ userId: userId });
+    return [timeout, action];
   }
 }


### PR DESCRIPTION
https://app.asana.com/0/1201648796371593/1201747143977580

This will need to be cherry picked into `rc`

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
`power.main` currently only checks the active account. It needs to check all authenticated accounts.

This is a bit tricky, because the main process's `stateService` instance isn't the same one used by the renderer, and the renderer is the one that maintains in memory account state. It works with currently for the active account because all information needed is pulled from disk storage, but the authenticated accounts list lives in memory. 

To overcome this, I decided to move the bulk of power.mains's timeout behavior into app.component and communicate via messages. This lets us use the same stateService everything else is using, that has the accounts list.

## Code changes
* Relocate some logic from power.main into messages handled by the app component

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
