### PR TITLE
Fix icons on the settings headers

### DIFF
--- a/src/app/accounts/settings.component.html
+++ b/src/app/accounts/settings.component.html
@@ -16,12 +16,12 @@
                   {{ "security" | i18n }}
                   <i
                     *ngIf="!showSecurity"
-                    class="fa fa-chevron-down fa-sm icon"
+                    class="bwi bwi-angle-down bwi-sm icon"
                     aria-hidden="true"
                   ></i>
                   <i
                     *ngIf="showSecurity"
-                    class="fa fa-chevron-up fa-sm icon"
+                    class="bwi bwi-chevron-up bwi-sm icon"
                     aria-hidden="true"
                   ></i>
                 </button>
@@ -121,12 +121,12 @@
                   {{ "accountPreferences" | i18n }}
                   <i
                     *ngIf="!showAccountPreferences"
-                    class="fa fa-chevron-down fa-sm icon"
+                    class="bwi bwi-angle-down bwi-sm icon"
                     aria-hidden="true"
                   ></i>
                   <i
                     *ngIf="showAccountPreferences"
-                    class="fa fa-chevron-up fa-sm icon"
+                    class="bwi bwi-chevron-up bwi-sm icon"
                     aria-hidden="true"
                   ></i>
                 </button>
@@ -192,12 +192,12 @@
                 {{ "appPreferences" | i18n }}
                 <i
                   *ngIf="!showAppPreferences"
-                  class="fa fa-chevron-down fa-sm icon"
+                  class="bwi bwi-angle-down bwi-sm icon"
                   aria-hidden="true"
                 ></i>
                 <i
                   *ngIf="showAppPreferences"
-                  class="fa fa-chevron-up fa-sm icon"
+                  class="bwi bwi-chevron-up bwi-sm icon"
                   aria-hidden="true"
                 ></i>
               </button>


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
A small issue from the icon update https://github.com/bitwarden/desktop/pull/1245. The settings menu still had the old icons (chevron-up/down) set. These replaces them with the new icons.

## Code changes
- **src/app/accounts/settings.component.html:** Replaced old icons with the new ones

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
