### PR TITLE
[bug] Remove scroll from login screen

### DIFF
--- a/src/app/accounts/login.component.html
+++ b/src/app/accounts/login.component.html
@@ -1,96 +1,98 @@
-<div class="login-header">
-  <a
-    href="#"
-    appStopClick
-    (click)="settings()"
-    class="environment-urls-settings-icon"
-    attr.aria-label="{{ 'settings' | i18n }}"
+<div id="login-page">
+  <div class="login-header">
+    <a
+      href="#"
+      appStopClick
+      (click)="settings()"
+      class="environment-urls-settings-icon"
+      attr.aria-label="{{ 'settings' | i18n }}"
+    >
+      <i class="bwi bwi-cog bwi-lg" aria-hidden="true"></i>
+      {{ "settings" | i18n }}
+    </a>
+  </div>
+  <form
+    id="login-page"
+    #form
+    (ngSubmit)="submit()"
+    [appApiAction]="formPromise"
+    attr.aria-hidden="{{ showingModal }}"
   >
-    <i class="bwi bwi-cog bwi-lg" aria-hidden="true"></i>
-    {{ "settings" | i18n }}
-  </a>
-</div>
-<form
-  id="login-page"
-  #form
-  (ngSubmit)="submit()"
-  [appApiAction]="formPromise"
-  attr.aria-hidden="{{ showingModal }}"
->
-  <div id="content" class="content">
-    <img class="logo-image" alt="Bitwarden" />
-    <p class="lead">{{ "loginOrCreateNewAccount" | i18n }}</p>
-    <div class="box last">
-      <div class="box-content">
-        <div class="box-content-row" appBoxRow>
-          <label for="email">{{ "emailAddress" | i18n }}</label>
-          <input
-            id="email"
-            type="text"
-            name="Email"
-            [(ngModel)]="email"
-            required
-            appInputVerbatim="false"
-          />
-        </div>
-        <div class="box-content-row box-content-row-flex" appBoxRow>
-          <div class="row-main">
-            <label for="masterPassword">{{ "masterPass" | i18n }}</label>
+    <div id="content" class="content">
+      <img class="logo-image" alt="Bitwarden" />
+      <p class="lead">{{ "loginOrCreateNewAccount" | i18n }}</p>
+      <div class="box last">
+        <div class="box-content">
+          <div class="box-content-row" appBoxRow>
+            <label for="email">{{ "emailAddress" | i18n }}</label>
             <input
-              id="masterPassword"
-              type="{{ showPassword ? 'text' : 'password' }}"
-              name="MasterPassword"
-              class="monospaced"
-              [(ngModel)]="masterPassword"
+              id="email"
+              type="text"
+              name="Email"
+              [(ngModel)]="email"
               required
-              appInputVerbatim
+              appInputVerbatim="false"
             />
           </div>
-          <div class="action-buttons">
-            <a
-              class="row-btn"
-              href="#"
-              appStopClick
-              appBlurClick
-              role="button"
-              appA11yTitle="{{ 'toggleVisibility' | i18n }}"
-              (click)="togglePassword()"
-            >
-              <i
-                class="bwi bwi-lg"
-                aria-hidden="true"
-                [ngClass]="{ 'bwi-eye': !showPassword, 'bwi-eye-slash': showPassword }"
-              ></i>
-            </a>
+          <div class="box-content-row box-content-row-flex" appBoxRow>
+            <div class="row-main">
+              <label for="masterPassword">{{ "masterPass" | i18n }}</label>
+              <input
+                id="masterPassword"
+                type="{{ showPassword ? 'text' : 'password' }}"
+                name="MasterPassword"
+                class="monospaced"
+                [(ngModel)]="masterPassword"
+                required
+                appInputVerbatim
+              />
+            </div>
+            <div class="action-buttons">
+              <a
+                class="row-btn"
+                href="#"
+                appStopClick
+                appBlurClick
+                role="button"
+                appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                (click)="togglePassword()"
+              >
+                <i
+                  class="bwi bwi-lg"
+                  aria-hidden="true"
+                  [ngClass]="{ 'bwi-eye': !showPassword, 'bwi-eye-slash': showPassword }"
+                ></i>
+              </a>
+            </div>
+          </div>
+          <div class="box-content-row" [hidden]="!showCaptcha()">
+            <iframe id="hcaptcha_iframe" height="80"></iframe>
           </div>
         </div>
-        <div class="box-content-row" [hidden]="!showCaptcha()">
-          <iframe id="hcaptcha_iframe" height="80"></iframe>
+      </div>
+
+      <div class="buttons with-rows">
+        <div class="buttons-row">
+          <button type="submit" class="btn primary block" [disabled]="form.loading" appBlurClick>
+            <b [hidden]="form.loading"
+              ><i class="bwi bwi-sign-in" aria-hidden="true"></i> {{ "logIn" | i18n }}</b
+            >
+            <i class="bwi bwi-spinner bwi-spin" [hidden]="!form.loading" aria-hidden="true"></i>
+          </button>
+          <a routerLink="/register" class="btn block">
+            <i class="bwi bwi-pencil-square" aria-hidden="true"></i> {{ "createAccount" | i18n }}
+          </a>
+        </div>
+        <div class="buttons-row">
+          <a (click)="launchSsoBrowser('desktop', 'bitwarden://sso-callback')" class="btn block">
+            <i class="bwi bwi-bank" aria-hidden="true"></i> {{ "enterpriseSingleSignOn" | i18n }}
+          </a>
         </div>
       </div>
-    </div>
-
-    <div class="buttons with-rows">
-      <div class="buttons-row">
-        <button type="submit" class="btn primary block" [disabled]="form.loading" appBlurClick>
-          <b [hidden]="form.loading"
-            ><i class="bwi bwi-sign-in" aria-hidden="true"></i> {{ "logIn" | i18n }}</b
-          >
-          <i class="bwi bwi-spinner bwi-spin" [hidden]="!form.loading" aria-hidden="true"></i>
-        </button>
-        <a routerLink="/register" class="btn block">
-          <i class="bwi bwi-pencil-square" aria-hidden="true"></i> {{ "createAccount" | i18n }}
-        </a>
-      </div>
-      <div class="buttons-row">
-        <a (click)="launchSsoBrowser('desktop', 'bitwarden://sso-callback')" class="btn block">
-          <i class="bwi bwi-bank" aria-hidden="true"></i> {{ "enterpriseSingleSignOn" | i18n }}
-        </a>
+      <div class="sub-options">
+        <a routerLink="/hint">{{ "getMasterPasswordHint" | i18n }}</a>
       </div>
     </div>
-    <div class="sub-options">
-      <a routerLink="/hint">{{ "getMasterPasswordHint" | i18n }}</a>
-    </div>
-  </div>
-</form>
+  </form>
+</div>
 <ng-template #environment></ng-template>

--- a/src/scss/pages.scss
+++ b/src/scss/pages.scss
@@ -139,28 +139,6 @@
   }
 }
 
-.login-header {
-  padding: 1em;
-  font-size: 1.2em;
-  .environment-urls-settings-icon {
-    @include themify($themes) {
-      color: themed("mutedColor");
-    }
-
-    span {
-      visibility: hidden;
-    }
-
-    &:hover,
-    &:focus {
-      text-decoration: none;
-
-      @include themify($themes) {
-        color: themed("primaryColor");
-      }
-    }
-  }
-}
 #sso-page {
   .content {
     width: 300px;
@@ -235,5 +213,33 @@
 #remove-password-page {
   .content > p {
     margin-bottom: 20px;
+  }
+}
+
+#login-page {
+  flex-direction: column;
+
+  .login-header {
+    align-self: flex-start;
+    padding: 1em;
+    font-size: 1.2em;
+    .environment-urls-settings-icon {
+      @include themify($themes) {
+        color: themed("mutedColor");
+      }
+
+      span {
+        visibility: hidden;
+      }
+
+      &:hover,
+      &:focus {
+        text-decoration: none;
+
+        @include themify($themes) {
+          color: themed("primaryColor");
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
https://app.asana.com/0/1201648796371593/1201754866744304

This will need to be cherry-picked to `rc`

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Scrolling should not be possible on the login screen, but is.

## Code changes
* Wrapped the entire login template in the `#login-page` id instead of just the form
  * I think this is the bulk of the issue. `#login-page` has `height: 100%` set, though it shares a container with the environment URLs button. The rest of these changes were just refactoring or supplemental to doing this.
* Set `flex-direction` on `#login-page` to column to align its top level fields correctly.
* Moved the `.login-header` styles inside of the `#login-page` scss identifier since those two should always be together.

## Screenshots
![Screen Shot 2022-02-02 at 9 25 01 AM](https://user-images.githubusercontent.com/15897251/152172532-e16c01c1-b33c-46be-8be2-e924e109ce34.png)
ot applicable-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
