### PR TITLE
Fix announcement of security header

### DIFF
--- a/src/app/accounts/vault-timeout-input.component.html
+++ b/src/app/accounts/vault-timeout-input.component.html
@@ -10,7 +10,6 @@
       name="VaultTimeout"
       formControlName="vaultTimeout"
       class="form-control"
-      appAutofocus
     >
       <option *ngFor="let o of vaultTimeouts" [ngValue]="o.value">{{ o.name }}</option>
     </select>


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
When using a screen reader on the settings dialog, the expansion/collapsing of the security header was not working as the vault-timeout component grabbed the focus.

Asana task: https://app.asana.com/0/1201648796371593/1201725701976421/f

This will need to get cherry picked 🍒 ⛏️ onto `rc`
## Code changes
- **src/app/accounts/vault-timeout-input.component.html:** Removed the appAutoFocus from the vaultTimeoutInput component

## Testing requirements
When using a screen reader, expansion/collapsing of the security header should be announced correctly

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
