### PR TITLE
[bug] Remove redundant token clean call

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -453,7 +453,6 @@ export class AppComponent implements OnInit {
     await Promise.all([
       this.eventService.uploadEvents(userBeingLoggedOut),
       this.syncService.setLastSync(new Date(0), userBeingLoggedOut),
-      this.tokenService.clearToken(userBeingLoggedOut),
       this.cryptoService.clearKeys(userBeingLoggedOut),
       this.settingsService.clear(userBeingLoggedOut),
       this.cipherService.clear(userBeingLoggedOut),


### PR DESCRIPTION
Depends on https://github.com/bitwarden/jslib/pull/661
This will need to be cherry-picked

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
WIth the move to sometimes storing tokens in memory we need to be careful about not clearing them redundantly, as that will throw an error if the value being checked is a memory variable.

## Code changes
* Remove the tokenService.clear() call from logout. We do this automatically on stateService.clean().
* Update jslib 

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
