### PR TITLE
[bug] Fix tab order regression

### DIFF
--- a/src/app/vault/vault.component.html
+++ b/src/app/vault/vault.component.html
@@ -1,17 +1,4 @@
 <div id="vault" class="vault" attr.aria-hidden="{{ showingModal }}">
-  <app-vault-groupings
-    id="groupings"
-    class="groupings"
-    (onAllClicked)="clearGroupingFilters()"
-    (onFavoritesClicked)="filterFavorites()"
-    (onCipherTypeClicked)="filterCipherType($event)"
-    (onFolderClicked)="filterFolder($event.id)"
-    (onAddFolder)="addFolder()"
-    (onEditFolder)="editFolder($event.id)"
-    (onCollectionClicked)="filterCollection($event.id)"
-    (onTrashClicked)="filterDeleted()"
-  >
-  </app-vault-groupings>
   <app-vault-ciphers
     id="items"
     class="items"
@@ -64,6 +51,19 @@
       </div>
     </div>
   </div>
+  <app-vault-groupings
+    id="groupings"
+    class="groupings"
+    (onAllClicked)="clearGroupingFilters()"
+    (onFavoritesClicked)="filterFavorites()"
+    (onCipherTypeClicked)="filterCipherType($event)"
+    (onFolderClicked)="filterFolder($event.id)"
+    (onAddFolder)="addFolder()"
+    (onEditFolder)="editFolder($event.id)"
+    (onCollectionClicked)="filterCollection($event.id)"
+    (onTrashClicked)="filterDeleted()"
+  >
+  </app-vault-groupings>
 </div>
 <ng-template #passwordGenerator></ng-template>
 <ng-template #attachments></ng-template>

--- a/src/scss/vault.scss
+++ b/src/scss/vault.scss
@@ -27,7 +27,20 @@ app-root {
     }
   }
 
+  > .items {
+    order: 2;
+  }
+
+  > .details {
+    order: 3;
+  }
+
+  > .logo {
+    order: 4;
+  }
+
   > .groupings {
+    order: 1;
     width: 22%;
     min-width: 175px;
     max-width: 250px;


### PR DESCRIPTION
Resolves https://github.com/bitwarden/desktop/issues/1325
https://app.asana.com/0/1201804463288267/1201808704441945

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Moving the search bar outside the context of the items list has causes a regression of our tabbing behavior. 

Previously, tabbing operated as such:
1. Search bar
2. Item list
3. Add item button
4. Item details (if applicable)
5. Groupings

Now, tabbing operates as:
1. Search bar
2. Account switcher
3. Groupings
4. Items
5. Add item button
6. Item details (if applicable)

This is certainly a worse UX. This PR puts things back the way they were, with the exception that the account switcher still comes before the item list in the focus order.

## Code changes
Ultimately, keyboard behavior in the desktop client is and was already poor - and this issue sparked a design conversation about expanding and improving that use case. This is something we're going to be taking a look at later and improving across the board, but for now has just been returned to the way it was in the last release. 

To achieve this, instead of putting tabIndex on everything in the entire application I moved the groupings component to the bottom of its template and added an explicit item order to the flex rules for the page. This lets us put groupings at the bottom of the DOM, making it the last thing to get tab focus, but still the first left-aligned item on screen.

I also updated jslib just because

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
