### PR TITLE
[Icons] Added missing custom field sort icon

### DIFF
--- a/src/app/vault/add-edit-custom-fields.component.html
+++ b/src/app/vault/add-edit-custom-fields.component.html
@@ -95,7 +95,7 @@
           </a>
         </div>
         <div class="drag-handle" appA11yTitle="{{ 'dragToSort' | i18n }}" cdkDragHandle>
-          <i class="bwi bwi-bars" aria-hidden="true"></i>
+          <i class="bwi bwi-hamburger" aria-hidden="true"></i>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
> Fix error in icon transition: update `bwi-bars` -> `bwi-hamburger`

## Code changes
- **add-edit-custom-fields.component.html:** Update `bwi-bars` -> `bwi-hamburger`

## Screenshots
![Screen Shot 2022-02-22 at 10 24 26 AM](https://user-images.githubusercontent.com/26154748/155177236-46b3cd0b-7b12-4e9d-a170-f6a1ded03d5d.png)

## Testing requirements
- Navigate to the Add/Edit cipher component
- Make sure you have a custom field line item
- Notice the drag/drop icon is visible

## Before you submit
- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
