### PR TITLE
[a11y] Accessibility fixes for account switcher menu

### DIFF
--- a/src/app/layout/account-switcher.component.html
+++ b/src/app/layout/account-switcher.component.html
@@ -5,8 +5,8 @@
   #trigger="cdkOverlayOrigin"
   [hidden]="!showSwitcher"
   aria-haspopup="menu"
-  aria-expanded="isOpen"
   aria-controls="cdk-overlay-container"
+  [attr.aria-expanded]="isOpen"
 >
   <ng-container *ngIf="activeAccountEmail != null; else noActiveAccount">
     <app-avatar
@@ -46,6 +46,8 @@
     [@transformPanel]="'open'"
     cdkTrapFocus
     cdkTrapFocusAutoCapture
+    role="dialog"
+    aria-modal="true"
   >
     <div class="accounts" *ngIf="numberOfAccounts > 0">
       <button


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fixes accessibility issues with the account switcher dropdown.
https://bitwarden.atlassian.net/browse/SG-57

## Code changes

- **src/app/layout/account-switcher.component.html:** 
 1. Correctly bind `isOpen` to the expanded value. It was getting passed as the string "isOpen" instead of evaluating to a boolean value, so it was always passing as true.
2. Add both the`role="dialog"` and `aria-modal="true"` values to the account switcher popup. This prevents the user from using reading key navigation to access content behind and around the switcher if it is open, causing confusion as to what options are present in the popup.

## Testing requirements

Using a screen reader: 
- ensure that the account switcher is correctly labeled as collapsed when it is not open.
- ensure that the user can not access links outside of the account switcher popup as they scroll through the available options with reading key navigation.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
