### PR TITLE
BEEEP: Colorize hidden custom field when value visible

### DIFF
--- a/src/app/vault/view-custom-fields.component.html
+++ b/src/app/vault/view-custom-fields.component.html
@@ -10,7 +10,11 @@
           {{ field.value || "&nbsp;" }}
         </div>
         <div *ngIf="field.type === fieldType.Hidden">
-          <span *ngIf="field.showValue" class="monospaced show-whitespace">{{ field.value }}</span>
+          <span
+            *ngIf="field.showValue"
+            class="monospaced show-whitespace"
+            [innerHTML]="field.value | colorPassword"
+          ></span>
           <span *ngIf="!field.showValue" class="monospaced">{{ field.maskedValue }}</span>
         </div>
         <div *ngIf="field.type === fieldType.Boolean">


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [X] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
The standard password field displays number and special characters in a different color for better readability. A hidden custom-field currently does not colorize it's value when shown.

Asana task: https://app.asana.com/0/1200804338582616/1201884248598925/f

## Code changes
- **src/app/vault/view-custom-fields.component.html:** Pass value into ColorPasswordPipe when hidden value is shown

## Screenshots
**BEFORE:**
![image](https://user-images.githubusercontent.com/2670567/155716436-8f9bef8b-5686-4e70-9d52-b37bce54f639.png)

**AFTER:**
![image](https://user-images.githubusercontent.com/2670567/155716243-5aaa8ccf-437b-41a2-ae53-1844b8e9a2c6.png)

## Testing requirements
When the value of a hidden custom field is shown, it should be colorized as the standard password field

## Before you submit

- [X] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
