### PR TITLE
[feature] Implement scope warning for exports

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -56,6 +56,7 @@ import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 
 import { AvatarComponent } from "jslib-angular/components/avatar.component";
 import { CalloutComponent } from "jslib-angular/components/callout.component";
+import { ExportScopeCalloutComponent } from "jslib-angular/components/export-scope-callout.component";
 import { IconComponent } from "jslib-angular/components/icon.component";
 import { BitwardenToastModule } from "jslib-angular/components/toastr.component";
 import { A11yTitleDirective } from "jslib-angular/directives/a11y-title.directive";
@@ -197,6 +198,7 @@ registerLocaleData(localeZhTw, "zh-TW");
     ColorPasswordPipe,
     EnvironmentComponent,
     ExportComponent,
+    ExportScopeCalloutComponent,
     FallbackSrcDirective,
     FolderAddEditComponent,
     GroupingsComponent,

--- a/src/app/vault/export.component.html
+++ b/src/app/vault/export.component.html
@@ -9,6 +9,7 @@
         >
           {{ "personalVaultExportPolicyInEffect" | i18n }}
         </app-callout>
+        <app-export-scope-callout *ngIf="!disabledByPolicy"></app-export-scope-callout>
         <div class="box">
           <div class="box-header" id="exportTitle">
             {{ "exportVault" | i18n }}

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -1816,5 +1816,17 @@
   },
   "sessionTimeout": {
     "message": "Your session has timed out. Please go back and try logging in again."
+  },
+  "exportingPersonalVaultTitle": {
+    "message": "Exporting Personal Vault"
+  },
+  "exportingPersonalVaultDescription": {
+    "message": "Only the personal vault items associated with $EMAIL$ will be exported. Organization vault items will not be included.",
+    "placeholders": {
+      "email": {
+        "content": "$1",
+        "example": "name@example.com"
+      }
+    }
   }
 }


### PR DESCRIPTION
https://app.asana.com/0/1183359552741420/1200074829339233

Depends on https://github.com/bitwarden/jslib/pull/688

## Type of change

- [ ] Bug fix
- [x] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
Exports are often confusing to users in organizations because there is no indication on screen that a personal export won't include organization items and vice versa. We should add an information panel to this screen noting what exactly is being exported.

## Code changes
- **app.module.ts:** Added an import for the `ExportScopeCalloutComponent` added to facilitate this information in `jslib`.
- **export.component.html:** Added an `<app-export-scope-callout>` element if the "Disable Personal Vault Export" policy is not enabled. 
- **messages.json:** Added strings used by the `ExportScopeCalloutComponent` in jslib.

## Screenshots
![Screen Shot 2022-02-17 at 3 23 29 PM](https://user-images.githubusercontent.com/15897251/154564612-171f9019-6edd-4346-9b71-9f625b7016f7.png)

## Testing requirements
We expect this warning to clearly label what is being exported. It should not appear if the user is not a part of any organizations.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
