### PR TITLE
Disable disk caching in stateService

### DIFF
--- a/src/app/services.module.ts
+++ b/src/app/services.module.ts
@@ -184,7 +184,8 @@ export function initFactory(
           secureStorageService,
           logService,
           stateMigrationService,
-          new StateFactory(GlobalState, Account)
+          new StateFactory(GlobalState, Account),
+          false // Do not use disk caching because this will get out of sync with the main process service
         ),
       deps: [
         StorageServiceAbstraction,

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,7 +83,8 @@ export class Main {
       null,
       this.logService,
       null,
-      new StateFactory(GlobalState, Account)
+      new StateFactory(GlobalState, Account),
+      false // Do not use disk caching because this will get out of sync with the renderer service
     );
 
     this.windowMain = new WindowMain(


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Fix https://app.asana.com/0/0/1201967392760891/f.

Steps to Reproduce
1. Open the Desktop app
2. Open Preferences and check "Minimize when copying to clipboard" 
3. Copy a vault item's field to the clipboard
4. Reopen the minimized app
5. Open Preferences and UN-check "Minimize when copying to clipboard" 
6. Copy a vault item's field to the clipboard

Expected Result
1. The app will no longer minimize after copying to clipboard

Actual Result
1. The app will still minimize after copying to clipboard
## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

This is because desktop runs a separate stateService in the main process, which only has access to onDisk storage. But each stateService caches separately and doesn't communicate with the other, so they get out of sync.

Given the impending release I have disabled caching in both stateService instances for this client. A better fix can be prioritized for next cycle.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
