### PR TITLE
Remove safari build script from Build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -671,9 +671,6 @@ jobs:
         run: |
           mkdir PlugIns
           cp -r dist-safari/browser/dist/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
-          ls -alh dist-safari/browser/dist/Safari/dmg/build/Release/safari.appex
-          ls -alh PlugIns
-          ls -alh PlugIns/safari.appex
 
       - name: Build application (dist)
         env:
@@ -860,7 +857,7 @@ jobs:
       - name: Load Safari extension for App Store
         run: |
           mkdir PlugIns
-          cp dist-safari/browser/dist/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
+          cp -r dist-safari/browser/dist/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application for App Store
         run: npm run pack:mac:mas
@@ -1039,7 +1036,7 @@ jobs:
       - name: Load Safari extension for App Store
         run: |
           mkdir PlugIns
-          cp dist-safari/browser/dist/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
+          cp -r dist-safari/browser/dist/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build dev application for App Store
         run: npm run pack:mac:masdev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -670,7 +670,10 @@ jobs:
       - name: Load Safari extension for .dmg
         run: |
           mkdir PlugIns
-          cp dist-safari/browser/dist/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
+          cp -r dist-safari/browser/dist/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
+          ls -alh dist-safari/browser/dist/Safari/dmg/build/Release/safari.appex
+          ls -alh PlugIns
+          ls -alh PlugIns/safari.appex
 
       - name: Build application (dist)
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -514,8 +514,10 @@ jobs:
           ref: ${{ needs.setup.outputs.safari_ref }}
 
       - name: Build Safari extension
-        shell: pwsh
-        run: ./scripts/safari-build.ps1 -skipcheckout -skipoutcopy
+        run: |
+          npm install
+          npm run dist:safari
+        working-directory: dist-safari/browser
 
 
   macos-package-github:
@@ -660,12 +662,15 @@ jobs:
 
       - name: Build Safari extension
         if: steps.safari-cache.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: ./scripts/safari-build.ps1 -skipcheckout -skipoutcopy
+        run: |
+          npm install
+          npm run dist:safari
+        working-directory: dist-safari/browser
 
       - name: Load Safari extension for .dmg
-        shell: pwsh
-        run: ./scripts/safari-build.ps1 -copyonly
+        run: |
+          mkdir PlugIns
+          cp dist-safari/browser/dist/Safari/dmg/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application (dist)
         env:
@@ -844,12 +849,15 @@ jobs:
 
       - name: Build Safari extension
         if: steps.safari-cache.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: ./scripts/safari-build.ps1 -skipcheckout -skipoutcopy
+        run: |
+          npm install
+          npm run dist:safari
+        working-directory: dist-safari/browser
 
       - name: Load Safari extension for App Store
-        shell: pwsh
-        run: ./scripts/safari-build.ps1 -mas -copyonly
+        run: |
+          mkdir PlugIns
+          cp dist-safari/browser/dist/Safari/mas/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build application for App Store
         run: npm run pack:mac:mas
@@ -1020,12 +1028,15 @@ jobs:
 
       - name: Build Safari extension
         if: steps.safari-cache.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: ./scripts/safari-build.ps1 -skipcheckout -skipoutcopy
+        run: |
+          npm install
+          npm run dist:safari
+        working-directory: dist-safari/browser
 
       - name: Load Safari extension for App Store
-        shell: pwsh
-        run: ./scripts/safari-build.ps1 -masdev -copyonly
+        run: |
+          mkdir PlugIns
+          cp dist-safari/browser/dist/Safari/masdev/build/Release/safari.appex PlugIns/safari.appex
 
       - name: Build dev application for App Store
         run: npm run pack:mac:masdev


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [X] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
This PR removes the `Safari Build` script from our `Build` workflow and replaces it with commands that run in a `bash` shell.

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **.github/workflows/build.yml:** Removed any PowerShell code for Safari Extension build.  Added logic in `bash` to perform the same actions as the build script.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [X] This change has particular **deployment requirements** (notify the DevOps team)
