### PR TITLE
PS-91 hide update menu option in mas builds

### DIFF
--- a/src/main/menu.about.ts
+++ b/src/main/menu.about.ts
@@ -2,7 +2,7 @@ import { BrowserWindow, clipboard, dialog, MenuItemConstructorOptions } from "el
 
 import { I18nService } from "jslib-common/abstractions/i18n.service";
 import { UpdaterMain } from "jslib-electron/updater.main";
-import { isSnapStore, isWindowsStore } from "jslib-electron/utils";
+import { isMacAppStore, isSnapStore, isWindowsStore } from "jslib-electron/utils";
 
 import { IMenubarMenu } from "./menubar";
 
@@ -42,7 +42,7 @@ export class AboutMenu implements IMenubarMenu {
     return {
       id: "checkForUpdates",
       label: this.localize("checkForUpdates"),
-      visible: !isWindowsStore() && !isSnapStore(),
+      visible: !isWindowsStore() && !isSnapStore() && isMacAppStore() == undefined,
       click: () => this.checkForUpdate(),
     };
   }

--- a/src/main/menu.first.ts
+++ b/src/main/menu.first.ts
@@ -40,7 +40,7 @@ export class FirstMenu {
       id: "checkForUpdates",
       label: this.localize("checkForUpdates"),
       click: (menuItem) => this.checkForUpdate(menuItem),
-      visible: !isMacAppStore() && !isWindowsStore() && !isSnapStore(),
+      visible: isMacAppStore() == undefined && !isWindowsStore() && !isSnapStore(),
     };
   }
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Our MAS build failed due to "Your app updates itself outside of the Mac App Store". We need to hide the update option from the Help menu if we build for MAS.

Fix will be cherry picked to `rc`

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **src/main/menu.about.ts:** hide update option if build is for MAS
- **src/main/menu.first.ts:** hide update option if build is for MAS

note: `isMacAppStore()` will return `undefined` if false. In the future we should revisit this to make sure it returns false, but I'm uncomfortable making that change in a hotfix for a release

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
