### PR TITLE
Fix "Custom environment", "Options" expand/collapse controls - wrong accessible name, state not exposed

### DIFF
--- a/src/app/accounts/environment.component.html
+++ b/src/app/accounts/environment.component.html
@@ -28,7 +28,8 @@
             <button
               type="button"
               (click)="toggleCustom()"
-              appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+              appA11yTitle="{{ 'customEnvironment' | i18n }}"
+              [attr.aria-expanded]="showCustom"
             >
               <i class="bwi bwi-plus-square" [hidden]="showCustom" aria-hidden="true"></i>
               <i class="bwi bwi-minus-square" [hidden]="!showCustom" aria-hidden="true"></i>

--- a/src/app/accounts/environment.component.html
+++ b/src/app/accounts/environment.component.html
@@ -25,12 +25,7 @@
         </div>
         <div class="box">
           <div class="box-header">
-            <button
-              type="button"
-              (click)="toggleCustom()"
-              appA11yTitle="{{ 'customEnvironment' | i18n }}"
-              [attr.aria-expanded]="showCustom"
-            >
+            <button type="button" (click)="toggleCustom()" [attr.aria-expanded]="showCustom">
               <i class="bwi bwi-plus-square" [hidden]="showCustom" aria-hidden="true"></i>
               <i class="bwi bwi-minus-square" [hidden]="!showCustom" aria-hidden="true"></i>
               {{ "customEnvironment" | i18n }}

--- a/src/app/vault/password-generator.component.html
+++ b/src/app/vault/password-generator.component.html
@@ -29,7 +29,8 @@
             <button
               type="button"
               (click)="toggleOptions()"
-              appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+              appA11yTitle="{{ 'options' | i18n }}"
+              [attr.aria-expanded]="showOptions"
             >
               <i class="bwi bwi-plus-square" aria-hidden="true" [hidden]="showOptions"></i>
               <i class="bwi bwi-minus-square" aria-hidden="true" [hidden]="!showOptions"></i>

--- a/src/app/vault/password-generator.component.html
+++ b/src/app/vault/password-generator.component.html
@@ -26,12 +26,7 @@
         </div>
         <div class="box">
           <div class="box-header">
-            <button
-              type="button"
-              (click)="toggleOptions()"
-              appA11yTitle="{{ 'options' | i18n }}"
-              [attr.aria-expanded]="showOptions"
-            >
+            <button type="button" (click)="toggleOptions()" [attr.aria-expanded]="showOptions">
               <i class="bwi bwi-plus-square" aria-hidden="true" [hidden]="showOptions"></i>
               <i class="bwi bwi-minus-square" aria-hidden="true" [hidden]="!showOptions"></i>
               {{ "options" | i18n }}


### PR DESCRIPTION
Closes #1440

## Type of change

- [X] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Corrects an error leading to a [WCAG 2.1 SC 2.5.3 Label in Name](https://www.w3.org/TR/WCAG21/#label-in-name) violation - currently, "Custom environment" and "Options" controls are exposed to assistive technologies as "Toggle Visibility". Further, the expand/collapse controls don't currently announce their state (expanded or collapsed). This rectifies it.

## Code changes

- remove the wrong (and now unnecessary) `appA11yTitle` from the two instances of expand/collapse controls
- add `aria-expanded` to announce the state of the expand/collapse control

## Screenshot

Video recording showing the current experience with a screenreader, compared to the experience after this PR is applied - using NVDA on Windows, with the Speech Viewer visible. Note how currently the control is wrongly announced as "Toggle Visibility button", and provides no indication of state, and how after this PR it announced it correctly as "Custom environment", and gives indication whether it's "expanded" or "collapsed"


https://user-images.githubusercontent.com/895831/160274853-342fa8e7-a671-47c8-91fb-2027b4fe05d9.mp4



## Testing requirements

- Test using a screen reader (e.g. NVDA on Windows)

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
