### PR TITLE
Add `aria-pressed` to all eye/toggle visibility buttons

### DIFF
--- a/src/app/accounts/lock.component.html
+++ b/src/app/accounts/lock.component.html
@@ -37,6 +37,7 @@
               appBlurClick
               role="button"
               appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+              [attr.aria-pressed]="showPassword"
               (click)="togglePassword()"
             >
               <i

--- a/src/app/accounts/login.component.html
+++ b/src/app/accounts/login.component.html
@@ -55,6 +55,7 @@
                 appBlurClick
                 role="button"
                 appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                [attr.aria-pressed]="showPassword"
                 (click)="togglePassword()"
               >
                 <i

--- a/src/app/accounts/register.component.html
+++ b/src/app/accounts/register.component.html
@@ -47,6 +47,7 @@
                 appBlurClick
                 role="button"
                 appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                [attr.aria-pressed]="showPassword"
                 (click)="togglePassword(false)"
               >
                 <i
@@ -97,6 +98,7 @@
               appBlurClick
               role="button"
               appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+              [attr.aria-pressed]="showPassword"
               (click)="togglePassword(true)"
             >
               <i

--- a/src/app/accounts/set-password.component.html
+++ b/src/app/accounts/set-password.component.html
@@ -63,6 +63,7 @@
                     appBlurClick
                     role="button"
                     appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                    [attr.aria-pressed]="showPassword"
                     (click)="togglePassword(false)"
                   >
                     <i
@@ -115,6 +116,7 @@
                     appBlurClick
                     role="button"
                     appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                    [attr.aria-pressed]="showPassword"
                     (click)="togglePassword(true)"
                   >
                     <i

--- a/src/app/accounts/update-temp-password.component.html
+++ b/src/app/accounts/update-temp-password.component.html
@@ -43,6 +43,7 @@
                 appBlurClick
                 role="button"
                 appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                [attr.aria-pressed]="showPassword"
                 (click)="togglePassword(false)"
               >
                 <i
@@ -90,6 +91,7 @@
               appBlurClick
               role="button"
               appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+              [attr.aria-pressed]="showPassword"
               (click)="togglePassword(true)"
             >
               <i

--- a/src/app/components/password-reprompt.component.html
+++ b/src/app/components/password-reprompt.component.html
@@ -26,6 +26,7 @@
                   appBlurClick
                   role="button"
                   appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                  [attr.aria-pressed]="showPassword"
                   (click)="togglePassword()"
                 >
                   <i

--- a/src/app/components/set-pin.component.html
+++ b/src/app/components/set-pin.component.html
@@ -28,6 +28,7 @@
                   appStopClick
                   appBlurClick
                   appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                  [attr.aria-pressed]="showPin"
                   (click)="toggleVisibility()"
                 >
                   <i

--- a/src/app/send/add-edit.component.html
+++ b/src/app/send/add-edit.component.html
@@ -164,6 +164,7 @@
                   appBlurClick
                   role="button"
                   appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                  [attr.aria-pressed]="showPassword"
                   (click)="togglePasswordVisible()"
                   [disabled]="disableSend"
                 >

--- a/src/app/vault/add-edit-custom-fields.component.html
+++ b/src/app/vault/add-edit-custom-fields.component.html
@@ -85,7 +85,7 @@
             appBlurClick
             role="button"
             appA11yTitle="{{ 'toggleVisibility' | i18n }}"
-            [attr.aria-pressed]="showValue"
+            [attr.aria-pressed]="f.showValue"
             (click)="toggleFieldValue(f)"
           >
             <i

--- a/src/app/vault/add-edit-custom-fields.component.html
+++ b/src/app/vault/add-edit-custom-fields.component.html
@@ -85,6 +85,7 @@
             appBlurClick
             role="button"
             appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+            [attr.aria-pressed]="showValue"
             (click)="toggleFieldValue(f)"
           >
             <i

--- a/src/app/vault/add-edit.component.html
+++ b/src/app/vault/add-edit.component.html
@@ -79,6 +79,7 @@
                   appBlurClick
                   role="button"
                   appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                  [attr.aria-pressed]="showPassword"
                   (click)="togglePassword()"
                 >
                   <i
@@ -144,6 +145,7 @@
                   appBlurClick
                   role="button"
                   appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                  [attr.aria-pressed]="showCardNumber"
                   (click)="toggleCardNumber()"
                 >
                   <i
@@ -198,6 +200,7 @@
                   appBlurClick
                   role="button"
                   appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                  [attr.aria-pressed]="showCardCode"
                   (click)="toggleCardCode()"
                 >
                   <i

--- a/src/app/vault/view.component.html
+++ b/src/app/vault/view.component.html
@@ -79,6 +79,7 @@
                 href="#"
                 appStopClick
                 appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                [attr.aria-pressed]="showPassword"
                 (click)="togglePassword()"
                 role="button"
               >
@@ -161,6 +162,7 @@
                 href="#"
                 appStopClick
                 appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                [attr.aria-pressed]="showCardNumber"
                 (click)="toggleCardNumber()"
                 role="button"
               >
@@ -202,6 +204,7 @@
                 href="#"
                 appStopClick
                 appA11yTitle="{{ 'toggleVisibility' | i18n }}"
+                [attr.aria-pressed]="showCardCode"
                 (click)="toggleCardCode()"
                 role="button"
               >


### PR DESCRIPTION
Closes #1442

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Adds `aria-pressed` to eye/toggle visibility buttons, so they expose their state to assistive technologies

## Code changes

- adds `aria-pressed`, with a value dependent on the state of the control

## Screenshot

Video recording showing the current experience with a screenreader, compared to the experience after this PR is applied - using NVDA on Windows, with the Speech Viewer visible. Note how currently the control is just announced as "Toggle Visibility button", with no indication of state, and how after this PR it announced that it's an actual toggle button, and gives indication whether it's "pressed" or "not pressed"


https://user-images.githubusercontent.com/895831/160274481-4481d045-361f-4989-bbb8-7898238a7840.mp4


## Testing requirements

- test using a screen reader (e.g. NVDA on Windows)

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
