### PR TITLE
Fix Mac App Store minimumSystemVersion

### DIFF
--- a/package.json
+++ b/package.json
@@ -187,7 +187,9 @@
       "entitlements": "resources/entitlements.mas.plist",
       "entitlementsInherit": "resources/entitlements.mas.inherit.plist",
       "hardenedRuntime": false,
-      "minimumSystemVersion": "10.14"
+      "extendInfo": {
+        "LSMinimumSystemVersion": "10.14.0"
+      }
     },
     "nsisWeb": {
       "oneClick": false,


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Seems #1428 did not work as expected. Falling back to the `extendInfo` method which worked on my machine using `masdev`.

Opened an issue to track this upstream, https://github.com/electron-userland/electron-builder/issues/6740

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
