### PR TITLE
Add electron:ignore which ignores invalid certificates

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build:renderer:dev": "cross-env NODE_ENV=development webpack --config webpack.renderer.js",
     "build:renderer:watch": "cross-env NODE_ENV=development webpack --config webpack.renderer.js --watch",
     "electron": "npm run build:main:dev && concurrently -k -n Main,Rend -c yellow,cyan \"electron --inspect=5858 ./build --watch\" \"npm run build:renderer:watch\"",
+    "electron:ignore": "npm run build:main:dev && concurrently -k -n Main,Rend -c yellow,cyan \"electron --inspect=5858 --ignore-certificate-errors ./build --watch\" \"npm run build:renderer:watch\"",
     "clean:dist": "rimraf ./dist/*",
     "clean:l10n": "git push origin --delete l10n_master",
     "pack:dir": "npm run clean:dist && electron-builder --dir -p never",


### PR DESCRIPTION
## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->
Adds `npm run electron:ignore` which ignores invalid certificates.

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
