### PR TITLE
Bump libsecret for rust

### DIFF
--- a/desktop_native/Cargo.lock
+++ b/desktop_native/Cargo.lock
@@ -343,9 +343,9 @@ checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libsecret"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b8d814edb0cb306ffded3f1bfe72d6689529f95f7313a718331802723a73e5a"
+checksum = "d4af5a2342942fa42d706a424e9f9914287fb8317132750fd73a241140ac38c1"
 dependencies = [
  "bitflags",
  "gio",

--- a/desktop_native/Cargo.toml
+++ b/desktop_native/Cargo.toml
@@ -40,4 +40,4 @@ security-framework-sys = "2.6.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 gio = "0.15.6"
-libsecret = "0.1.3"
+libsecret = "0.1.4"


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

Bumps libsecret to 0.1.4, resolves #1479 

PS-188
EC-141

## Before you submit

- [ ] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
