### PR TITLE
[CP-96] Capitalize menu items consistently

### DIFF
--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -775,7 +775,7 @@
     "description": "A 'fingerprint phrase' is a unique word phrase (similar to a passphrase) that a user can use to authenticate their public key with another user, for the purposes of sharing."
   },
   "goToWebVault": {
-    "message": "Go To Web Vault"
+    "message": "Go to Web Vault"
   },
   "getMobileApp": {
     "message": "Get Mobile App"
@@ -973,7 +973,7 @@
     "description": "Copy to clipboard"
   },
   "checkForUpdates": {
-    "message": "Check For Updates"
+    "message": "Check for Updates…"
   },
   "version": {
     "message": "Version $VERSION_NUM$",
@@ -985,7 +985,7 @@
     }
   },
   "restartToUpdate": {
-    "message": "Restart To Update"
+    "message": "Restart to Update"
   },
   "restartToUpdateDesc": {
     "message": "Version $VERSION_NUM$ is ready to install. You must restart the application to complete the installation. Do you want to restart and update now?",


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective
This pull request makes the capitalization consistent for menu items across English dialects and uses word capitalization rules for short prepositions.
<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

The use of "Check for Updates…" in other apps appears to be almost universal and replaces "Check For Updates" (en) and "Check for updates" (en_GB/en_IN).

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
