### PR TITLE
fix disabling of generate type

### DIFF
--- a/src/app/vault/generator.component.html
+++ b/src/app/vault/generator.component.html
@@ -81,7 +81,7 @@
                   [value]="o.value"
                   (change)="typeChanged()"
                   [checked]="type === o.value"
-                  [disabled]="comingFromAddEdit"
+                  [disabled]="comingFromAddEdit && type !== o.value"
                 />
                 <label class="unstyled" for="type_{{ o.value }}">
                   {{ o.name }}


### PR DESCRIPTION
## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Show current selection as enabled on generator type option when "coming from add/edit" page.

## Code changes

- generator component view - Expended condition in `[disable]` attribute to only include types that are not the current selection.

## Screenshots

<!--Required for any UI changes. Delete if not applicable-->
![image](https://user-images.githubusercontent.com/1190944/164024634-4f4b35eb-a566-40ea-856f-394e969828b9.png)



## Testing requirements

Test generating usernames and passwords from add/edit page.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
