### PR TITLE
Widen the sidebar to 600px max

### DIFF
--- a/src/scss/vault.scss
+++ b/src/scss/vault.scss
@@ -43,7 +43,7 @@ app-root {
     order: 1;
     width: 22%;
     min-width: 175px;
-    max-width: 250px;
+    max-width: 600px;
     border-right: 1px solid #000000;
 
     @include themify($themes) {


### PR DESCRIPTION
This implements the suggestion by MrBlack of the community forums in: https://community.bitwarden.com/t/manually-resizable-sidebar-columns-in-bitwarden-desktop-app/31909/3

## Type of change

- [ ] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [x] Other

## Objective

https://community.bitwarden.com/t/manually-resizable-sidebar-columns-in-bitwarden-desktop-app/31909

## Code changes

- **src/scss/vault.scss:** Set `max-width` to 600px

## Screenshots

![image](https://user-images.githubusercontent.com/16440184/165246033-c6190cd5-de7a-4c2d-96bc-f028ac796b50.png)

## Testing requirements

I do not see any.

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
