### PR TITLE
Issue 1419 - if biometric lock is already being used assume it is still supported

### DIFF
--- a/src/main/biometric/biometric.darwin.main.ts
+++ b/src/main/biometric/biometric.darwin.main.ts
@@ -22,7 +22,10 @@ export default class BiometricDarwinMain implements BiometricMain {
   }
 
   supportsBiometric(): Promise<boolean> {
-    return Promise.resolve(systemPreferences.canPromptTouchID());
+    return Promise.resolve(
+      // Issue 1419 - if the biometric unlock is already set allowed this make sure we still support it (clam-shell)
+      systemPreferences.canPromptTouchID() || this.stateService.getBiometricUnlock()
+    );
   }
 
   async authenticateBiometric(): Promise<boolean> {


### PR DESCRIPTION

## Type of change

- [x] Bug fix
- [ ] New feature development
- [ ] Tech debt (refactoring, code cleanup, dependency upgrades, etc)
- [ ] Build/deploy pipeline (DevOps)
- [ ] Other

## Objective

Fixes the behavior described in issue 1419 where the biometric unlock option is removed when the application is started in clam-shell mode.

<!--Describe what the purpose of this PR is. For example: what bug you're fixing or what new feature you're adding-->

## Code changes

<!--Explain the changes you've made to each file or major component. This should help the reviewer understand your changes-->
<!--Also refer to any related changes or PRs in other repositories-->

- **biometric.darwin.main.ts** If the biometric unlock setting is already applied assume that the biometrics are supported still.

## Testing requirements

<!--What functionality requires testing by QA? This includes testing new behavior and regression testing-->
logging in with biometrics on mac in clam-shell mode using Apple Watch
logging in with biometrics on mac using touch id with the laptop opened

## Before you submit

- [x] I have checked for **linting** errors (`npm run lint`) (required)
- [ ] This change requires a **documentation update** (notify the documentation team)
- [ ] This change has particular **deployment requirements** (notify the DevOps team)
